### PR TITLE
Add destructors for resource cleanup

### DIFF
--- a/DirectX12/ConstantBuffer.cpp
+++ b/DirectX12/ConstantBuffer.cpp
@@ -4,12 +4,12 @@
 ConstantBuffer::ConstantBuffer(size_t size)
 {
     size_t align = D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT;
-    UINT64 sizeAligned = (size + (align - 1)) & ~(align - 1); // align‚ÉØ‚èã‚°‚é.
+    UINT64 sizeAligned = (size + (align - 1)) & ~(align - 1); // alignã«åˆ‡ã‚Šä¸Šã’ã‚‹.
 
-    auto prop = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD); // ƒq[ƒvƒvƒƒpƒeƒB
-    auto desc = CD3DX12_RESOURCE_DESC::Buffer(sizeAligned); // ƒŠƒ\[ƒX‚ÌÝ’è
+    auto prop = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD); // ãƒ’ãƒ¼ãƒ—ãƒ—ãƒ­ãƒ‘ãƒ†ã‚£
+    auto desc = CD3DX12_RESOURCE_DESC::Buffer(sizeAligned); // ãƒªã‚½ãƒ¼ã‚¹ã®è¨­å®š
 
-    // ƒŠƒ\[ƒX‚ð¶¬
+    // ãƒªã‚½ãƒ¼ã‚¹ã‚’ç”Ÿæˆ
     auto hr = g_Engine->Device()->CreateCommittedResource(
         &prop,
         D3D12_HEAP_FLAG_NONE,
@@ -19,18 +19,18 @@ ConstantBuffer::ConstantBuffer(size_t size)
         IID_PPV_ARGS(m_pBuffer.GetAddressOf()));
     if (FAILED(hr))
     {
-        printf("’è”ƒoƒbƒtƒ@ƒŠƒ\[ƒX‚Ì¶¬‚ÉŽ¸”s\n");
+        printf("å®šæ•°ãƒãƒƒãƒ•ã‚¡ãƒªã‚½ãƒ¼ã‚¹ã®ç”Ÿæˆã«å¤±æ•—\n");
         return;
     }
     else
     {
-        printf("’è”ƒoƒbƒtƒ@ƒŠƒ\[ƒX‚Ì¶¬ ¬Œ÷\n");
+        printf("å®šæ•°ãƒãƒƒãƒ•ã‚¡ãƒªã‚½ãƒ¼ã‚¹ã®ç”Ÿæˆ æˆåŠŸ\n");
     }
 
 
     hr = m_pBuffer->Map(0, nullptr, &m_pMappedPtr);
     if (!m_pBuffer) {
-        printf("m_pBuffer‚ª‹ó‚Å‚·\n");
+        printf("m_pBufferãŒç©ºã§ã™\n");
         return;
     }
 
@@ -63,3 +63,10 @@ void* ConstantBuffer::GetPtr() const
     return m_pMappedPtr;
 }
 
+ConstantBuffer::~ConstantBuffer()
+{
+    if (m_pBuffer) {
+        m_pBuffer->Unmap(0, nullptr);
+    }
+    m_pBuffer.Reset();
+}

--- a/DirectX12/ConstantBuffer.h
+++ b/DirectX12/ConstantBuffer.h
@@ -5,12 +5,13 @@
 class ConstantBuffer
 {
 public:
-    ConstantBuffer(size_t size); // ƒRƒ“ƒXƒgƒ‰ƒNƒ^‚Å’è”ƒoƒbƒtƒ@‚ğ¶¬
-    bool IsValid(); // ƒoƒbƒtƒ@¶¬‚É¬Œ÷‚µ‚½‚©‚ğ•Ô‚·
-    D3D12_GPU_VIRTUAL_ADDRESS GetAddress() const; // ƒoƒbƒtƒ@‚ÌGPUã‚ÌƒAƒhƒŒƒX‚ğ•Ô‚·
-    D3D12_CONSTANT_BUFFER_VIEW_DESC ViewDesc(); // ’è”ƒoƒbƒtƒ@ƒrƒ…[‚ğ•Ô‚·
+    ~ConstantBuffer();
+    ConstantBuffer(size_t size); // ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿ã§å®šæ•°ãƒãƒƒãƒ•ã‚¡ã‚’ç”Ÿæˆ
+    bool IsValid(); // ãƒãƒƒãƒ•ã‚¡ç”Ÿæˆã«æˆåŠŸã—ãŸã‹ã‚’è¿”ã™
+    D3D12_GPU_VIRTUAL_ADDRESS GetAddress() const; // ãƒãƒƒãƒ•ã‚¡ã®GPUä¸Šã®ã‚¢ãƒ‰ãƒ¬ã‚¹ã‚’è¿”ã™
+    D3D12_CONSTANT_BUFFER_VIEW_DESC ViewDesc(); // å®šæ•°ãƒãƒƒãƒ•ã‚¡ãƒ“ãƒ¥ãƒ¼ã‚’è¿”ã™
 
-    void* GetPtr() const; // ’è”ƒoƒbƒtƒ@‚Éƒ}ƒbƒsƒ“ƒO‚³‚ê‚½ƒ|ƒCƒ“ƒ^‚ğ•Ô‚·
+    void* GetPtr() const; // å®šæ•°ãƒãƒƒãƒ•ã‚¡ã«ãƒãƒƒãƒ”ãƒ³ã‚°ã•ã‚ŒãŸãƒã‚¤ãƒ³ã‚¿ã‚’è¿”ã™
 
     template<typename T>
     T* GetPtr()
@@ -19,9 +20,9 @@ public:
     }
 
 private:
-    bool m_IsValid = false; // ’è”ƒoƒbƒtƒ@¶¬‚É¬Œ÷‚µ‚½‚©
-    ComPtr<ID3D12Resource> m_pBuffer; // ’è”ƒoƒbƒtƒ@
-    D3D12_CONSTANT_BUFFER_VIEW_DESC m_Desc; // ’è”ƒoƒbƒtƒ@ƒrƒ…[‚Ìİ’è
+    bool m_IsValid = false; // å®šæ•°ãƒãƒƒãƒ•ã‚¡ç”Ÿæˆã«æˆåŠŸã—ãŸã‹
+    ComPtr<ID3D12Resource> m_pBuffer; // å®šæ•°ãƒãƒƒãƒ•ã‚¡
+    D3D12_CONSTANT_BUFFER_VIEW_DESC m_Desc; // å®šæ•°ãƒãƒƒãƒ•ã‚¡ãƒ“ãƒ¥ãƒ¼ã®è¨­å®š
     void* m_pMappedPtr = nullptr;
 
     ConstantBuffer(const ConstantBuffer&) = delete;

--- a/DirectX12/DescriptorHeap.h
+++ b/DirectX12/DescriptorHeap.h
@@ -16,9 +16,10 @@ public:
 class DescriptorHeap
 {
 public:
-	DescriptorHeap(); // ƒRƒ“ƒXƒgƒ‰ƒNƒ^‚Å¶¬‚·‚é
-	ID3D12DescriptorHeap* GetHeap(); // ƒfƒBƒXƒNƒŠƒvƒ^ƒq[ƒv‚ğ•Ô‚·
-	DescriptorHandle* Register(Texture2D* texture); // ƒeƒNƒXƒ`ƒƒ[‚ğƒfƒBƒXƒNƒŠƒvƒ^ƒq[ƒv‚É“o˜^‚µAƒnƒ“ƒhƒ‹‚ğ•Ô‚·
+        DescriptorHandle* Register(Texture2D* texture); // eNX`[fBXNv^q[vÉ“o^AnhÔ‚
+        ~DescriptorHeap();
+	ID3D12DescriptorHeap* GetHeap(); // ãƒ‡ã‚£ã‚¹ã‚¯ãƒªãƒ—ã‚¿ãƒ’ãƒ¼ãƒ—ã‚’è¿”ã™
+	DescriptorHandle* Register(Texture2D* texture); // ãƒ†ã‚¯ã‚¹ãƒãƒ£ãƒ¼ã‚’ãƒ‡ã‚£ã‚¹ã‚¯ãƒªãƒ—ã‚¿ãƒ’ãƒ¼ãƒ—ã«ç™»éŒ²ã—ã€ãƒãƒ³ãƒ‰ãƒ«ã‚’è¿”ã™
 	DescriptorHandle* RegisterBuffer(
 		ID3D12Resource* resource,
 		UINT            numElements,
@@ -26,9 +27,9 @@ public:
 	);
 
 private:
-	bool m_IsValid = false; // ¶¬‚É¬Œ÷‚µ‚½‚©‚Ç‚¤‚©
+	bool m_IsValid = false; // ç”Ÿæˆã«æˆåŠŸã—ãŸã‹ã©ã†ã‹
 	UINT m_IncrementSize = 0;
-	ComPtr<ID3D12DescriptorHeap> m_pHeap = nullptr; // ƒfƒBƒXƒNƒŠƒvƒ^ƒq[ƒv–{‘Ì
-	std::vector<DescriptorHandle*> m_pHandles; // “o˜^‚³‚ê‚Ä‚¢‚éƒnƒ“ƒhƒ‹
+	ComPtr<ID3D12DescriptorHeap> m_pHeap = nullptr; // ãƒ‡ã‚£ã‚¹ã‚¯ãƒªãƒ—ã‚¿ãƒ’ãƒ¼ãƒ—æœ¬ä½“
+	std::vector<DescriptorHandle*> m_pHandles; // ç™»éŒ²ã•ã‚Œã¦ã„ã‚‹ãƒãƒ³ãƒ‰ãƒ«
 
 };

--- a/DirectX12/DiscriptorHeap.cpp
+++ b/DirectX12/DiscriptorHeap.cpp
@@ -18,7 +18,7 @@ DescriptorHeap::DescriptorHeap()
 
 	auto device = g_Engine->Device();
 
-	// ƒfƒBƒXƒNƒŠƒvƒ^ƒq[ƒv‚ð¶¬
+	// ãƒ‡ã‚£ã‚¹ã‚¯ãƒªãƒ—ã‚¿ãƒ’ãƒ¼ãƒ—ã‚’ç”Ÿæˆ
 	auto hr = device->CreateDescriptorHeap(
 		&desc,
 		IID_PPV_ARGS(m_pHeap.ReleaseAndGetAddressOf()));
@@ -29,7 +29,7 @@ DescriptorHeap::DescriptorHeap()
 		return;
 	}
 
-	m_IncrementSize = device->GetDescriptorHandleIncrementSize(desc.Type); // ƒfƒBƒXƒNƒŠƒvƒ^ƒq[ƒv1ŒÂ‚Ìƒƒ‚ƒŠƒTƒCƒY‚ð•Ô‚·
+	m_IncrementSize = device->GetDescriptorHandleIncrementSize(desc.Type); // ãƒ‡ã‚£ã‚¹ã‚¯ãƒªãƒ—ã‚¿ãƒ’ãƒ¼ãƒ—1å€‹ã®ãƒ¡ãƒ¢ãƒªã‚µã‚¤ã‚ºã‚’è¿”ã™
 	m_IsValid = true;
 }
 
@@ -48,11 +48,11 @@ DescriptorHandle* DescriptorHeap::Register(Texture2D* texture)
 
 	DescriptorHandle* pHandle = new DescriptorHandle();
 
-	auto handleCPU = m_pHeap->GetCPUDescriptorHandleForHeapStart(); // ƒfƒBƒXƒNƒŠƒvƒ^ƒq[ƒv‚ÌÅ‰‚ÌƒAƒhƒŒƒX
-	handleCPU.ptr += m_IncrementSize * count; // Å‰‚ÌƒAƒhƒŒƒX‚©‚çcount”Ô–Ú‚ª¡‰ñ’Ç‰Á‚³‚ê‚½ƒŠƒ\[ƒX‚Ìƒnƒ“ƒhƒ‹
+	auto handleCPU = m_pHeap->GetCPUDescriptorHandleForHeapStart(); // ãƒ‡ã‚£ã‚¹ã‚¯ãƒªãƒ—ã‚¿ãƒ’ãƒ¼ãƒ—ã®æœ€åˆã®ã‚¢ãƒ‰ãƒ¬ã‚¹
+	handleCPU.ptr += m_IncrementSize * count; // æœ€åˆã®ã‚¢ãƒ‰ãƒ¬ã‚¹ã‹ã‚‰countç•ªç›®ãŒä»Šå›žè¿½åŠ ã•ã‚ŒãŸãƒªã‚½ãƒ¼ã‚¹ã®ãƒãƒ³ãƒ‰ãƒ«
 
-	auto handleGPU = m_pHeap->GetGPUDescriptorHandleForHeapStart(); // ƒfƒBƒXƒNƒŠƒvƒ^ƒq[ƒv‚ÌÅ‰‚ÌƒAƒhƒŒƒX
-	handleGPU.ptr += m_IncrementSize * count; // Å‰‚ÌƒAƒhƒŒƒX‚©‚çcount”Ô–Ú‚ª¡‰ñ’Ç‰Á‚³‚ê‚½ƒŠƒ\[ƒX‚Ìƒnƒ“ƒhƒ‹
+	auto handleGPU = m_pHeap->GetGPUDescriptorHandleForHeapStart(); // ãƒ‡ã‚£ã‚¹ã‚¯ãƒªãƒ—ã‚¿ãƒ’ãƒ¼ãƒ—ã®æœ€åˆã®ã‚¢ãƒ‰ãƒ¬ã‚¹
+	handleGPU.ptr += m_IncrementSize * count; // æœ€åˆã®ã‚¢ãƒ‰ãƒ¬ã‚¹ã‹ã‚‰countç•ªç›®ãŒä»Šå›žè¿½åŠ ã•ã‚ŒãŸãƒªã‚½ãƒ¼ã‚¹ã®ãƒãƒ³ãƒ‰ãƒ«
 
 	pHandle->HandleCPU = handleCPU;
 	pHandle->HandleGPU = handleGPU;
@@ -60,10 +60,10 @@ DescriptorHandle* DescriptorHeap::Register(Texture2D* texture)
 	auto device = g_Engine->Device();
 	auto resource = texture->Resource();
 	auto desc = texture->ViewDesc();
-	device->CreateShaderResourceView(resource, &desc, pHandle->HandleCPU); // ƒVƒF[ƒ_[ƒŠƒ\[ƒXƒrƒ…[ì¬
+	device->CreateShaderResourceView(resource, &desc, pHandle->HandleCPU); // ã‚·ã‚§ãƒ¼ãƒ€ãƒ¼ãƒªã‚½ãƒ¼ã‚¹ãƒ“ãƒ¥ãƒ¼ä½œæˆ
 
 	m_pHandles.push_back(pHandle);
-	return pHandle; // ƒnƒ“ƒhƒ‹‚ð•Ô‚·
+	return pHandle; // ãƒãƒ³ãƒ‰ãƒ«ã‚’è¿”ã™
 }
 
 DescriptorHandle* DescriptorHeap::RegisterBuffer(
@@ -76,7 +76,16 @@ DescriptorHandle* DescriptorHeap::RegisterBuffer(
 
 	auto pHandle = new DescriptorHandle();
 
-	// CPU/GPU —¼•û‚Ìƒnƒ“ƒhƒ‹‚ðŽæ“¾
+DescriptorHeap::~DescriptorHeap()
+{
+        for (auto handle : m_pHandles) {
+                delete handle;
+        }
+        m_pHandles.clear();
+        m_pHeap.Reset();
+        m_IsValid = false;
+}
+	// CPU/GPU ä¸¡æ–¹ã®ãƒãƒ³ãƒ‰ãƒ«ã‚’å–å¾—
 	auto cpu = m_pHeap->GetCPUDescriptorHandleForHeapStart();
 	cpu.ptr += m_IncrementSize * count;
 	auto gpu = m_pHeap->GetGPUDescriptorHandleForHeapStart();
@@ -85,7 +94,7 @@ DescriptorHandle* DescriptorHeap::RegisterBuffer(
 	pHandle->HandleCPU = cpu;
 	pHandle->HandleGPU = gpu;
 
-	// SRV ƒfƒXƒNƒŠƒvƒ^‚ðì¬
+	// SRV ãƒ‡ã‚¹ã‚¯ãƒªãƒ—ã‚¿ã‚’ä½œæˆ
 	D3D12_SHADER_RESOURCE_VIEW_DESC desc{};
 	desc.Format = DXGI_FORMAT_UNKNOWN;
 	desc.ViewDimension = D3D12_SRV_DIMENSION_BUFFER;
@@ -94,7 +103,7 @@ DescriptorHandle* DescriptorHeap::RegisterBuffer(
 	desc.Buffer.StructureByteStride = stride;
 	desc.Buffer.Flags = D3D12_BUFFER_SRV_FLAG_NONE;
 
-	// ŽÀÛ‚É GPU ‚Öƒrƒ…[‚ð‘‚«ž‚Þ
+	// å®Ÿéš›ã« GPU ã¸ãƒ“ãƒ¥ãƒ¼ã‚’æ›¸ãè¾¼ã‚€
 	g_Engine->Device()->CreateShaderResourceView(
 		resource, &desc, cpu);
 

--- a/DirectX12/FluidSystem.cpp
+++ b/DirectX12/FluidSystem.cpp
@@ -16,31 +16,31 @@ void FluidSystem::Init(ID3D12Device* device, DXGI_FORMAT rtvFormat,
 
 	CD3DX12_ROOT_SIGNATURE_DESC rsDesc(1, &rp, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_NONE);
 
-	// ƒVƒŠƒAƒ‰ƒCƒY
+	// ã‚·ãƒªã‚¢ãƒ©ã‚¤ã‚º
 	ComPtr<ID3DBlob> blob, errBlob;
 	HRESULT hr = D3D12SerializeRootSignature(&rsDesc, D3D_ROOT_SIGNATURE_VERSION_1, &blob, &errBlob);
 	if (FAILED(hr)) {
 		if (errBlob) {
 			OutputDebugStringA((char*)errBlob->GetBufferPointer());
 		}
-		wprintf(L"RootSignature ƒVƒŠƒAƒ‰ƒCƒY¸”s: 0x%08X\n", hr);
+		wprintf(L"RootSignature ã‚·ãƒªã‚¢ãƒ©ã‚¤ã‚ºå¤±æ•—: 0x%08X\n", hr);
 		return;
 	}
 
-	// ƒ‹[ƒgƒVƒOƒlƒ`ƒƒ¶¬
+	// ãƒ«ãƒ¼ãƒˆã‚·ã‚°ãƒãƒãƒ£ç”Ÿæˆ
 	hr = device->CreateRootSignature(0, blob->GetBufferPointer(), blob->GetBufferSize(), IID_PPV_ARGS(&m_computeRS));
 	if (FAILED(hr)) {
-		wprintf(L"[Error] RootSignature ¶¬¸”s: 0x%08X\n", hr);
+		wprintf(L"[Error] RootSignature ç”Ÿæˆå¤±æ•—: 0x%08X\n", hr);
 		return;
 	}
 
-	// ComputePSO‚ğ‰Šú‰»
+	// ComputePSOã‚’åˆæœŸåŒ–
 	m_computePS.SetDevice(device);
 	m_computePS.SetRootSignature(m_computeRS.Get());
 	m_computePS.SetCS(L"ParticleCS.cso");
 	m_computePS.Create();
 
-	// —±qƒoƒbƒtƒ@‚ÆUAVƒq[ƒv
+	// ç²’å­ãƒãƒƒãƒ•ã‚¡ã¨UAVãƒ’ãƒ¼ãƒ—
 	D3D12_RESOURCE_DESC rd = CD3DX12_RESOURCE_DESC::Buffer(sizeof(ParticleMeta) * maxParticles, D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
 	CD3DX12_HEAP_PROPERTIES heapProps(D3D12_HEAP_TYPE_DEFAULT);
 	device->CreateCommittedResource(&heapProps, D3D12_HEAP_FLAG_NONE, &rd, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, nullptr, IID_PPV_ARGS(&m_particleBuffer));
@@ -56,8 +56,8 @@ void FluidSystem::Init(ID3D12Device* device, DXGI_FORMAT rtvFormat,
 	uavd.Buffer.StructureByteStride = sizeof(ParticleMeta);
 	device->CreateUnorderedAccessView(m_particleBuffer.Get(), nullptr, &uavd, m_uavHeap->GetCPUDescriptorHandleForHeapStart());
 
-	// •`‰æ—pƒpƒCƒvƒ‰ƒCƒ“¶¬
-	// ƒ‹[ƒgƒVƒOƒlƒ`ƒƒ
+	// æç”»ç”¨ãƒ‘ã‚¤ãƒ—ãƒ©ã‚¤ãƒ³ç”Ÿæˆ
+	// ãƒ«ãƒ¼ãƒˆã‚·ã‚°ãƒãƒãƒ£
 	CD3DX12_DESCRIPTOR_RANGE graRange;
 	range.Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0);
 	CD3DX12_ROOT_PARAMETER graRootParam[2];
@@ -77,7 +77,7 @@ void FluidSystem::Init(ID3D12Device* device, DXGI_FORMAT rtvFormat,
 	m_graphicsPS->SetPS(L"MetaBallPS.cso");
 	m_graphicsPS->Create(D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE);
 
-	// SRV ƒq[ƒv
+	// SRV ãƒ’ãƒ¼ãƒ—
 	D3D12_DESCRIPTOR_HEAP_DESC hd2 = {};
 	hd2.NumDescriptors = 1;
 	hd2.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
@@ -92,7 +92,7 @@ void FluidSystem::Init(ID3D12Device* device, DXGI_FORMAT rtvFormat,
 	device->CreateShaderResourceView(m_particleBuffer.Get(), &srvd,
 		m_graphicsSrvHeap->GetCPUDescriptorHandleForHeapStart());
 
-	// ’è”ƒoƒbƒtƒ@
+	// å®šæ•°ãƒãƒƒãƒ•ã‚¡
 	D3D12_HEAP_PROPERTIES hp = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
 	D3D12_RESOURCE_DESC   cbd = CD3DX12_RESOURCE_DESC::Buffer(sizeof(DirectX::XMFLOAT4X4) +
 		sizeof(DirectX::XMFLOAT3) + sizeof(UINT) + 4);
@@ -100,7 +100,7 @@ void FluidSystem::Init(ID3D12Device* device, DXGI_FORMAT rtvFormat,
 		D3D12_RESOURCE_STATE_GENERIC_READ, nullptr,
 		IID_PPV_ARGS(&m_graphicsCB));
 
-	// ƒAƒbƒvƒ[ƒhƒq[ƒv‚ğì¬
+	// ã‚¢ãƒƒãƒ—ãƒ­ãƒ¼ãƒ‰ãƒ’ãƒ¼ãƒ—ã‚’ä½œæˆ
 	CD3DX12_HEAP_PROPERTIES uploadProps(D3D12_HEAP_TYPE_UPLOAD);
 	CD3DX12_RESOURCE_DESC   uploadDesc =
 		CD3DX12_RESOURCE_DESC::Buffer(sizeof(ParticleMeta) * m_maxParticles);
@@ -116,7 +116,7 @@ void FluidSystem::Init(ID3D12Device* device, DXGI_FORMAT rtvFormat,
 
 void FluidSystem::Simulate(ID3D12GraphicsCommandList* cmd, float dt) {
 	if (m_useGpu) {
-		// GPU ƒVƒ~ƒ…ƒŒ[ƒVƒ‡ƒ“
+		// GPU ã‚·ãƒŸãƒ¥ãƒ¬ãƒ¼ã‚·ãƒ§ãƒ³
 		auto uavBarrier = CD3DX12_RESOURCE_BARRIER::UAV(m_particleBuffer.Get());
 		cmd->ResourceBarrier(1, &uavBarrier);
 		cmd->SetComputeRootSignature(m_computeRS.Get());
@@ -128,12 +128,12 @@ void FluidSystem::Simulate(ID3D12GraphicsCommandList* cmd, float dt) {
 		cmd->Dispatch(m_threadGroupCount, 1, 1);
 	}
 	else {
-		// CPU ƒVƒ~ƒ…ƒŒ[ƒVƒ‡ƒ“
+		// CPU ã‚·ãƒŸãƒ¥ãƒ¬ãƒ¼ã‚·ãƒ§ãƒ³
 		for (UINT i = 0; i < m_maxParticles; ++i) {
-			// m_cpuParticles[i].pos ‚ğXV (ŠÈˆÕ—áFY+=dt)
+			// m_cpuParticles[i].pos ã‚’æ›´æ–° (ç°¡æ˜“ä¾‹ï¼šY+=dt)
 			m_cpuParticles[i].pos.y += dt;
 		}
-		// CPU¨GPU “]‘—
+		// CPUâ†’GPU è»¢é€
 		D3D12_SUBRESOURCE_DATA srcData = {};
 		srcData.pData = m_cpuParticles.data();
 		srcData.RowPitch = sizeof(ParticleMeta) * m_maxParticles;
@@ -143,7 +143,11 @@ void FluidSystem::Simulate(ID3D12GraphicsCommandList* cmd, float dt) {
 }
 
 void FluidSystem::Render(ID3D12GraphicsCommandList* cmd, const DirectX::XMFLOAT4X4& invViewProj, const DirectX::XMFLOAT3& camPos, float isoLevel) {
-	// ’è”ƒoƒbƒtƒ@XV
+FluidSystem::~FluidSystem()
+{
+        delete m_graphicsPS;
+}
+	// å®šæ•°ãƒãƒƒãƒ•ã‚¡æ›´æ–°
 	struct MetaCB { DirectX::XMFLOAT4X4 invVP; DirectX::XMFLOAT3 cam; float iso; UINT count; } cb;
 	cb.invVP = invViewProj;
 	cb.cam = camPos;
@@ -154,7 +158,7 @@ void FluidSystem::Render(ID3D12GraphicsCommandList* cmd, const DirectX::XMFLOAT4
 	memcpy(p, &cb, sizeof(cb));
 	m_graphicsCB->Unmap(0, nullptr);
 
-	// •`‰æ
+	// æç”»
 	cmd->SetDescriptorHeaps(1, m_graphicsSrvHeap.GetAddressOf());
 	cmd->SetGraphicsRootSignature(m_graphicsRS.Get());
 	cmd->SetPipelineState(m_graphicsPS->Get());

--- a/DirectX12/FluidSystem.h
+++ b/DirectX12/FluidSystem.h
@@ -10,37 +10,38 @@
 
 class FluidSystem {
 public:
-    // ‰Šú‰»: ƒfƒoƒCƒXERTVŒ`®EÅ‘å—±q”EƒXƒŒƒbƒhƒOƒ‹[ƒv”
+    ~FluidSystem();
+    // åˆæœŸåŒ–: ãƒ‡ãƒã‚¤ã‚¹ãƒ»RTVå½¢å¼ãƒ»æœ€å¤§ç²’å­æ•°ãƒ»ã‚¹ãƒ¬ãƒƒãƒ‰ã‚°ãƒ«ãƒ¼ãƒ—æ•°
     void Init(ID3D12Device* device, DXGI_FORMAT rtvFormat,
         UINT maxParticles, UINT threadGroupCount);
 
-    // CPU/GPU Ø‚è‘Ö‚¦
+    // CPU/GPU åˆ‡ã‚Šæ›¿ãˆ
     void UseGPU(bool enable) { m_useGpu = enable; }
 
-    // ƒVƒ~ƒ…ƒŒ[ƒVƒ‡ƒ“ (CPU or ComputeShader)
+    // ã‚·ãƒŸãƒ¥ãƒ¬ãƒ¼ã‚·ãƒ§ãƒ³ (CPU or ComputeShader)
     void Simulate(ID3D12GraphicsCommandList* cmd, float dt);
 
-    // 3Dƒƒ^ƒ{[ƒ‹•`‰æ
+    // 3Dãƒ¡ã‚¿ãƒœãƒ¼ãƒ«æç”»
     void Render(ID3D12GraphicsCommandList* cmd,
         const DirectX::XMFLOAT4X4& invViewProj,
         const DirectX::XMFLOAT3& camPos,
         float isoLevel);
 
 private:
-    // CPU ‘¤ƒp[ƒeƒBƒNƒ‹”z—ñ
+    // CPU å´ãƒ‘ãƒ¼ãƒ†ã‚£ã‚¯ãƒ«é…åˆ—
     std::vector<ParticleMeta>     m_cpuParticles;
 
-    // GPU —pƒoƒbƒtƒ@ (SRV/UAV‹¤—p)
+    // GPU ç”¨ãƒãƒƒãƒ•ã‚¡ (SRV/UAVå…±ç”¨)
     ComPtr<ID3D12Resource>        m_particleBuffer;
-    ComPtr<ID3D12DescriptorHeap>  m_uavHeap;      // UAV ‚ğ‚Âƒq[ƒv
-    ComPtr<ID3D12DescriptorHeap>  m_graphicsSrvHeap; // SRV —pƒq[ƒv
+    ComPtr<ID3D12DescriptorHeap>  m_uavHeap;      // UAV ã‚’æŒã¤ãƒ’ãƒ¼ãƒ—
+    ComPtr<ID3D12DescriptorHeap>  m_graphicsSrvHeap; // SRV ç”¨ãƒ’ãƒ¼ãƒ—
     ComPtr<ID3D12Resource>        m_uploadHeap;
 
-    // ƒRƒ“ƒsƒ…[ƒg—pƒpƒCƒvƒ‰ƒCƒ“
+    // ã‚³ãƒ³ãƒ”ãƒ¥ãƒ¼ãƒˆç”¨ãƒ‘ã‚¤ãƒ—ãƒ©ã‚¤ãƒ³
     ComPtr<ID3D12RootSignature>    m_computeRS;
     ComputePipelineState           m_computePS;
 
-    // •`‰æ—pƒpƒCƒvƒ‰ƒCƒ“
+    // æç”»ç”¨ãƒ‘ã‚¤ãƒ—ãƒ©ã‚¤ãƒ³
     ComPtr<ID3D12RootSignature>    m_graphicsRS;
     PipelineState* m_graphicsPS;
     ComPtr<ID3D12Resource>         m_graphicsCB;

--- a/DirectX12/Particle.cpp
+++ b/DirectX12/Particle.cpp
@@ -162,5 +162,17 @@ void Particle::UpdateVertexBuffer() {
 	void* ptr = nullptr;
 	m_VertexBuffer->GetResource()->Map(0, nullptr, &ptr);
 	memcpy(ptr, vertices.data(), sizeof(ParticleVertex) * vertices.size());
+
 	m_VertexBuffer->GetResource()->Unmap(0, nullptr);
+
+}
+Particle::~Particle()
+{
+        delete m_VertexBuffer;
+        for (size_t i = 0; i < Engine::FRAME_BUFFER_COUNT; i++) {
+                delete m_ConstantBuffer[i];
+                m_ConstantBuffer[i] = nullptr;
+        }
+        delete m_RootSignature;
+        delete m_PipelineState;
 }

--- a/DirectX12/Particle.h
+++ b/DirectX12/Particle.h
@@ -22,12 +22,13 @@ private:
 	PipelineState* m_PipelineState = nullptr;
 	ConstantBuffer* m_ConstantBuffer[Engine::FRAME_BUFFER_COUNT] = {};
 
-	// グラフィックス描画用
+        ~Particle();
+	// 繧ｰ繝ｩ繝輔ぅ繝�繧ｯ繧ｹ謠冗判逕ｨ
 	ComPtr<ID3D12RootSignature>    m_graphicsRS;
 	PipelineState*				   m_graphicsPS;
 	ComPtr<ID3D12Resource>         m_graphicsCB;
 
-	// コンピュート用
+	// 繧ｳ繝ｳ繝斐Η繝ｼ繝育畑
 	ComPtr<ID3D12RootSignature>    m_computeRS;
 	PipelineState*				   m_computePS;
 	ComPtr<ID3D12Resource>         m_computeUAV;

--- a/DirectX12/Scene.cpp
+++ b/DirectX12/Scene.cpp
@@ -28,9 +28,9 @@ PipelineState* pipelineState;
 IndexBuffer* indexBuffer;
 const wchar_t* modelFile = L"assets/korosuke.fbx";
 
-std::vector<Mesh> meshes;					// ƒƒbƒVƒ…‚Ì”z—ñ
-std::vector<VertexBuffer*> vertexBuffers;	// ƒƒbƒVƒ…‚Ì”•ª‚Ì’¸“_ƒoƒbƒtƒ@
-std::vector<IndexBuffer*> indexBuffers;		// ƒƒbƒVƒ…‚Ì”•ª‚ÌƒCƒ“ƒfƒbƒNƒXƒoƒbƒtƒ@
+std::vector<Mesh> meshes;					// ãƒ¡ãƒƒã‚·ãƒ¥ã®é…åˆ—
+std::vector<VertexBuffer*> vertexBuffers;	// ãƒ¡ãƒƒã‚·ãƒ¥ã®æ•°åˆ†ã®é ‚ç‚¹ãƒãƒƒãƒ•ã‚¡
+std::vector<IndexBuffer*> indexBuffers;		// ãƒ¡ãƒƒã‚·ãƒ¥ã®æ•°åˆ†ã®ã‚¤ãƒ³ãƒ‡ãƒƒã‚¯ã‚¹ãƒãƒƒãƒ•ã‚¡
 
 namespace fs = std::filesystem;
 
@@ -46,7 +46,7 @@ std::wstring ReplaceExtension(const std::wstring& origin, const char* ext)
 }
 
 DescriptorHeap* descriptorHeap;
-std::vector< DescriptorHandle*> materialHandles; // ƒeƒNƒXƒ`ƒƒ—p‚Ìƒnƒ“ƒhƒ‹ˆê——
+std::vector< DescriptorHandle*> materialHandles; // ãƒ†ã‚¯ã‚¹ãƒãƒ£ç”¨ã®ãƒãƒ³ãƒ‰ãƒ«ä¸€è¦§
 
 bool Scene::Init()
 {
@@ -61,12 +61,12 @@ bool Scene::Init()
 		ptr->Proj = camera->GetProjMatrix();
 	}
 
-	ImportSettings importSetting =				// ©ì‚Ì“Ç‚İ‚İİ’è\‘¢‘Ì
+	ImportSettings importSetting =				// è‡ªä½œã®èª­ã¿è¾¼ã¿è¨­å®šæ§‹é€ ä½“
 	{
 		modelFile,
 		meshes,
 		false,
-		true // ƒAƒŠƒVƒA‚Ìƒ‚ƒfƒ‹‚ÍAƒeƒNƒXƒ`ƒƒ‚ÌUV‚ÌV‚¾‚¯”½“]‚µ‚Ä‚é‚Á‚Û‚¢H‚Ì‚Å“Ç‚İ‚İ‚ÉUVÀ•W‚ğ‹t“]‚³‚¹‚é
+		true // ã‚¢ãƒªã‚·ã‚¢ã®ãƒ¢ãƒ‡ãƒ«ã¯ã€ãƒ†ã‚¯ã‚¹ãƒãƒ£ã®UVã®Vã ã‘åè»¢ã—ã¦ã‚‹ã£ã½ã„ï¼Ÿã®ã§èª­ã¿è¾¼ã¿æ™‚ã«UVåº§æ¨™ã‚’é€†è»¢ã•ã›ã‚‹
 	};
 
 	AssimpLoader loader;
@@ -75,7 +75,7 @@ bool Scene::Init()
 		return false;
 	}
 
-	// ƒƒbƒVƒ…‚Ì”‚¾‚¯’¸“_ƒoƒbƒtƒ@‚ğ—pˆÓ‚·‚é
+	// ãƒ¡ãƒƒã‚·ãƒ¥ã®æ•°ã ã‘é ‚ç‚¹ãƒãƒƒãƒ•ã‚¡ã‚’ç”¨æ„ã™ã‚‹
 	vertexBuffers.reserve(meshes.size());
 	for (size_t i = 0; i < meshes.size(); i++)
 	{
@@ -85,14 +85,14 @@ bool Scene::Init()
 		auto pVB = new VertexBuffer(size, stride, vertices);
 		if (!pVB->IsValid())
 		{
-			printf("’¸“_ƒoƒbƒtƒ@‚Ì¶¬‚É¸”s\n");
+			printf("é ‚ç‚¹ãƒãƒƒãƒ•ã‚¡ã®ç”Ÿæˆã«å¤±æ•—\n");
 			return false;
 		}
 
 		vertexBuffers.push_back(pVB);
 	}
 
-	// ƒƒbƒVƒ…‚Ì”‚¾‚¯ƒCƒ“ƒfƒbƒNƒXƒoƒbƒtƒ@‚ğ—pˆÓ‚·‚é
+	// ãƒ¡ãƒƒã‚·ãƒ¥ã®æ•°ã ã‘ã‚¤ãƒ³ãƒ‡ãƒƒã‚¯ã‚¹ãƒãƒƒãƒ•ã‚¡ã‚’ç”¨æ„ã™ã‚‹
 	indexBuffers.reserve(meshes.size());
 	for (size_t i = 0; i < meshes.size(); i++)
 	{
@@ -101,56 +101,56 @@ bool Scene::Init()
 		auto pIB = new IndexBuffer(size, indices);
 		if (!pIB->IsValid())
 		{
-			printf("ƒCƒ“ƒfƒbƒNƒXƒoƒbƒtƒ@‚Ì¶¬‚É¸”s\n");
+			printf("ã‚¤ãƒ³ãƒ‡ãƒƒã‚¯ã‚¹ãƒãƒƒãƒ•ã‚¡ã®ç”Ÿæˆã«å¤±æ•—\n");
 			return false;
 		}
 
 		indexBuffers.push_back(pIB);
 	}
 
-	// ƒ}ƒeƒŠƒAƒ‹‚Ì“Ç‚İ‚İ
+	// ãƒãƒ†ãƒªã‚¢ãƒ«ã®èª­ã¿è¾¼ã¿
 	materialHandles.clear();
 	descriptorHeap = new DescriptorHeap();
 	for (size_t i = 0; i < meshes.size(); i++)
 	{
-		// ƒeƒNƒXƒ`ƒƒƒtƒ@ƒCƒ‹ƒpƒX‚Ì¶¬iTGAŒ`®‚É•ÏŠ·j
+		// ãƒ†ã‚¯ã‚¹ãƒãƒ£ãƒ•ã‚¡ã‚¤ãƒ«ãƒ‘ã‚¹ã®ç”Ÿæˆï¼ˆTGAå½¢å¼ã«å¤‰æ›ï¼‰
 		auto texPath = ReplaceExtension(meshes[i].DiffuseMap, "png");
 
-		// ƒeƒNƒXƒ`ƒƒ‚ğ“Ç‚İ‚Ş
+		// ãƒ†ã‚¯ã‚¹ãƒãƒ£ã‚’èª­ã¿è¾¼ã‚€
 		auto mainTex = Texture2D::Get(texPath);
 
-		// ƒeƒNƒXƒ`ƒƒ‚ªŒ©‚Â‚©‚ç‚È‚¢ê‡AƒfƒtƒHƒ‹ƒg‚ÌƒeƒNƒXƒ`ƒƒ‚ğg—p
+		// ãƒ†ã‚¯ã‚¹ãƒãƒ£ãŒè¦‹ã¤ã‹ã‚‰ãªã„å ´åˆã€ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆã®ãƒ†ã‚¯ã‚¹ãƒãƒ£ã‚’ä½¿ç”¨
 		if (!mainTex) {
-			printf("ƒeƒNƒXƒ`ƒƒ‚Ì“Ç‚İ‚İ‚É¸”s‚µ‚Ü‚µ‚½: %ws ¨ ƒfƒtƒHƒ‹ƒg‚ÌƒeƒNƒXƒ`ƒƒ‚ğg—p‚µ‚Ü‚·\n", texPath.c_str());
+			printf("ãƒ†ã‚¯ã‚¹ãƒãƒ£ã®èª­ã¿è¾¼ã¿ã«å¤±æ•—ã—ã¾ã—ãŸ: %ws â†’ ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆã®ãƒ†ã‚¯ã‚¹ãƒãƒ£ã‚’ä½¿ç”¨ã—ã¾ã™\n", texPath.c_str());
 
-			// ‰¼‚ÌƒfƒtƒHƒ‹ƒgƒeƒNƒXƒ`ƒƒi—á‚¦‚Î”’F‚ÌƒeƒNƒXƒ`ƒƒj‚ğg—p‚·‚é
+			// ä»®ã®ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆãƒ†ã‚¯ã‚¹ãƒãƒ£ï¼ˆä¾‹ãˆã°ç™½è‰²ã®ãƒ†ã‚¯ã‚¹ãƒãƒ£ï¼‰ã‚’ä½¿ç”¨ã™ã‚‹
 			mainTex = Texture2D::Get(L"assets/default.png");
 
 			if (!mainTex) {
-				printf("ƒfƒtƒHƒ‹ƒg‚ÌƒeƒNƒXƒ`ƒƒ‚à“Ç‚İ‚ß‚Ü‚¹‚ñ‚Å‚µ‚½B\n");
-				continue;  // ƒfƒtƒHƒ‹ƒgƒeƒNƒXƒ`ƒƒ‚à“Ç‚İ‚ß‚È‚¯‚ê‚ÎŸ‚ÌƒƒbƒVƒ…‚Öi‚Ş
+				printf("ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆã®ãƒ†ã‚¯ã‚¹ãƒãƒ£ã‚‚èª­ã¿è¾¼ã‚ã¾ã›ã‚“ã§ã—ãŸã€‚\n");
+				continue;  // ãƒ‡ãƒ•ã‚©ãƒ«ãƒˆãƒ†ã‚¯ã‚¹ãƒãƒ£ã‚‚èª­ã¿è¾¼ã‚ãªã‘ã‚Œã°æ¬¡ã®ãƒ¡ãƒƒã‚·ãƒ¥ã¸é€²ã‚€
 			}
 		}
 
-		// ƒeƒNƒXƒ`ƒƒ‚ª–³–‚Éæ“¾‚Å‚«‚½ê‡AƒfƒBƒXƒNƒŠƒvƒ^ƒq[ƒv‚É“o˜^
+		// ãƒ†ã‚¯ã‚¹ãƒãƒ£ãŒç„¡äº‹ã«å–å¾—ã§ããŸå ´åˆã€ãƒ‡ã‚£ã‚¹ã‚¯ãƒªãƒ—ã‚¿ãƒ’ãƒ¼ãƒ—ã«ç™»éŒ²
 		auto handle = descriptorHeap->Register(mainTex);
 		if (!handle) {
 			printf("Register() failed: handle is nullptr\n");
-			continue;  // “o˜^‚É¸”s‚µ‚½ê‡‚ÍŸ‚ÌƒƒbƒVƒ…‚Öi‚Ş
+			continue;  // ç™»éŒ²ã«å¤±æ•—ã—ãŸå ´åˆã¯æ¬¡ã®ãƒ¡ãƒƒã‚·ãƒ¥ã¸é€²ã‚€
 		}
 
-		materialHandles.push_back(handle);  // ƒnƒ“ƒhƒ‹‚ğ•Û
+		materialHandles.push_back(handle);  // ãƒãƒ³ãƒ‰ãƒ«ã‚’ä¿æŒ
 	}
 
-	// ƒ‹[ƒgƒVƒOƒlƒ`ƒƒ[‚Ìì¬
+	// ãƒ«ãƒ¼ãƒˆã‚·ã‚°ãƒãƒãƒ£ãƒ¼ã®ä½œæˆ
 	rootSignature = new RootSignature();
 	if (!rootSignature->IsValid())
 	{
-		printf("ƒ‹[ƒgƒVƒOƒlƒ`ƒƒ‚Ì¶¬‚É¸”s\n");
+		printf("ãƒ«ãƒ¼ãƒˆã‚·ã‚°ãƒãƒãƒ£ã®ç”Ÿæˆã«å¤±æ•—\n");
 		return false;
 	}
 
-	// ƒpƒCƒvƒ‰ƒCƒ“ƒXƒe[ƒg‚Ìì¬
+	// ãƒ‘ã‚¤ãƒ—ãƒ©ã‚¤ãƒ³ã‚¹ãƒ†ãƒ¼ãƒˆã®ä½œæˆ
 	pipelineState = new PipelineState();
 	pipelineState->SetInputLayout(Vertex::InputLayout);
 	pipelineState->SetRootSignature(rootSignature->Get());
@@ -159,11 +159,11 @@ bool Scene::Init()
 	pipelineState->Create(D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE);
 	if (!pipelineState->IsValid())
 	{
-		printf("ƒpƒCƒvƒ‰ƒCƒ“ƒXƒe[ƒg‚Ì¶¬‚É¸”s\n");
+		printf("ãƒ‘ã‚¤ãƒ—ãƒ©ã‚¤ãƒ³ã‚¹ãƒ†ãƒ¼ãƒˆã®ç”Ÿæˆã«å¤±æ•—\n");
 		return false;
 	}
 
-	printf("ƒV[ƒ“‚Ì‰Šú‰»‚É¬Œ÷\n");
+	printf("ã‚·ãƒ¼ãƒ³ã®åˆæœŸåŒ–ã«æˆåŠŸ\n");
 	return true;
 }
 
@@ -185,7 +185,41 @@ void Scene::Draw()
 {
 	auto currentIndex = g_Engine->CurrentBackBufferIndex();
 	auto commandList = g_Engine->CommandList();
-	auto materialHeap = descriptorHeap->GetHeap(); // ƒfƒBƒXƒNƒŠƒvƒ^ƒq[ƒv
+Scene::~Scene()
+{
+        for (size_t i = 0; i < Engine::FRAME_BUFFER_COUNT; i++) {
+                delete constantBuffer[i];
+                constantBuffer[i] = nullptr;
+        }
+
+        for (auto vb : vertexBuffers) {
+                delete vb;
+        }
+        vertexBuffers.clear();
+
+        for (auto ib : indexBuffers) {
+                delete ib;
+        }
+        indexBuffers.clear();
+
+        for (auto handle : materialHandles) {
+                delete handle;
+        }
+        materialHandles.clear();
+
+        delete descriptorHeap;
+        descriptorHeap = nullptr;
+
+        delete rootSignature;
+        rootSignature = nullptr;
+        delete pipelineState;
+        pipelineState = nullptr;
+
+        delete camera;
+        camera = nullptr;
+        printf("Scene\xE7\xB5\xB3\xE4\xBA\x86\n");
+}
+	auto materialHeap = descriptorHeap->GetHeap(); // ãƒ‡ã‚£ã‚¹ã‚¯ãƒªãƒ—ã‚¿ãƒ’ãƒ¼ãƒ—
 
 	for (size_t i = 0; i < meshes.size(); i++)
 	{
@@ -200,8 +234,8 @@ void Scene::Draw()
 		commandList->IASetVertexBuffers(0, 1, &vbView);
 		commandList->IASetIndexBuffer(&ibView);
 
-		commandList->SetDescriptorHeaps(1, &materialHeap); // g—p‚·‚éƒfƒBƒXƒNƒŠƒvƒ^ƒq[ƒv‚ğƒZƒbƒg
-		commandList->SetGraphicsRootDescriptorTable(1, materialHandles[i]->HandleGPU); // ‚»‚ÌƒƒbƒVƒ…‚É‘Î‰‚·‚éƒfƒBƒXƒNƒŠƒvƒ^ƒe[ƒuƒ‹‚ğƒZƒbƒg
+		commandList->SetDescriptorHeaps(1, &materialHeap); // ä½¿ç”¨ã™ã‚‹ãƒ‡ã‚£ã‚¹ã‚¯ãƒªãƒ—ã‚¿ãƒ’ãƒ¼ãƒ—ã‚’ã‚»ãƒƒãƒˆ
+		commandList->SetGraphicsRootDescriptorTable(1, materialHandles[i]->HandleGPU); // ãã®ãƒ¡ãƒƒã‚·ãƒ¥ã«å¯¾å¿œã™ã‚‹ãƒ‡ã‚£ã‚¹ã‚¯ãƒªãƒ—ã‚¿ãƒ†ãƒ¼ãƒ–ãƒ«ã‚’ã‚»ãƒƒãƒˆ
 
 		commandList->DrawIndexedInstanced(meshes[i].Indices.size(), 1, 0, 0, 0);
 	}

--- a/DirectX12/Scene.h
+++ b/DirectX12/Scene.h
@@ -11,9 +11,10 @@ private:
 
 public:
 	Scene(Game* game);
-	bool Init();	// ‰Šú‰»
-	void Update(float deltaTime);	// XVˆ—
-	void Draw();	// •`‰æˆ—
+        ~Scene();
+	bool Init();	// Ââ€°Å Ãºâ€°Â»
+	void Update(float deltaTime);	// ÂXÂVÂË†â€”Â
+	void Draw();	// â€¢`â€°Ã¦ÂË†â€”Â
 };
 
 extern Scene* g_Scene;

--- a/DirectX12/Texture2D.cpp
+++ b/DirectX12/Texture2D.cpp
@@ -6,7 +6,7 @@
 
 using namespace DirectX;
 
-// std::string(ƒ}ƒ‹ƒ`ƒoƒCƒg•¶š—ñ)‚©‚çstd::wstring(ƒƒCƒh•¶š—ñ)‚ğ“¾‚é
+// std::string(ãƒãƒ«ãƒãƒã‚¤ãƒˆæ–‡å­—åˆ—)ã‹ã‚‰std::wstring(ãƒ¯ã‚¤ãƒ‰æ–‡å­—åˆ—)ã‚’å¾—ã‚‹
 std::wstring GetWideString(const std::string& str)
 {
 	auto num1 = MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED | MB_ERR_INVALID_CHARS, str.c_str(), -1, nullptr, 0);
@@ -20,7 +20,7 @@ std::wstring GetWideString(const std::string& str)
 	return wstr;
 }
 
-// Šg’£q‚ğ•Ô‚·
+// æ‹¡å¼µå­ã‚’è¿”ã™
 std::wstring FileExtension(const std::wstring& path)
 {
 	auto idx = path.rfind(L'.');
@@ -51,17 +51,17 @@ bool Texture2D::Load(std::string& path)
 
 bool Texture2D::Load(std::wstring& path)
 {
-	//WICƒeƒNƒXƒ`ƒƒ‚Ìƒ[ƒh
+	//WICãƒ†ã‚¯ã‚¹ãƒãƒ£ã®ãƒ­ãƒ¼ãƒ‰
 	TexMetadata meta = {};
 	ScratchImage scratch = {};
 	auto ext = FileExtension(path);
 
 	HRESULT hr = S_FALSE;
-	if (ext == L"png") // png‚Ì‚ÍWICFile‚ğg‚¤
+	if (ext == L"png") // pngã®æ™‚ã¯WICFileã‚’ä½¿ã†
 	{
 		LoadFromWICFile(path.c_str(), WIC_FLAGS_NONE, &meta, scratch);
 	}
-	else if (ext == L"tga") // tga‚Ì‚ÍTGAFile‚ğg‚¤
+	else if (ext == L"tga") // tgaã®æ™‚ã¯TGAFileã‚’ä½¿ã†
 	{
 		hr = LoadFromTGAFile(path.c_str(), &meta, scratch);
 	}
@@ -83,7 +83,7 @@ bool Texture2D::Load(std::wstring& path)
 		static_cast<UINT16>(meta.arraySize),
 		static_cast<UINT16>(meta.mipLevels));
 
-	// ƒŠƒ\[ƒX‚ğ¶¬
+	// ãƒªã‚½ãƒ¼ã‚¹ã‚’ç”Ÿæˆ
 	hr = g_Engine->Device()->CreateCommittedResource(
 		&prop,
 		D3D12_HEAP_FLAG_NONE,
@@ -99,10 +99,10 @@ bool Texture2D::Load(std::wstring& path)
 	}
 
 	hr = m_pResource->WriteToSubresource(0,
-		nullptr, //‘S—Ìˆæ‚ÖƒRƒs[
-		img->pixels, //Œ³ƒf[ƒ^ƒAƒhƒŒƒX
-		static_cast<UINT>(img->rowPitch), //1ƒ‰ƒCƒ“ƒTƒCƒY
-		static_cast<UINT>(img->slicePitch) //‘SƒTƒCƒY
+		nullptr, //å…¨é ˜åŸŸã¸ã‚³ãƒ”ãƒ¼
+		img->pixels, //å…ƒãƒ‡ãƒ¼ã‚¿ã‚¢ãƒ‰ãƒ¬ã‚¹
+		static_cast<UINT>(img->rowPitch), //1ãƒ©ã‚¤ãƒ³ã‚µã‚¤ã‚º
+		static_cast<UINT>(img->slicePitch) //å…¨ã‚µã‚¤ã‚º
 	);
 	if (FAILED(hr))
 	{
@@ -123,7 +123,7 @@ Texture2D* Texture2D::Get(std::wstring path)
 	auto tex = new Texture2D(path);
 	if (!tex->IsValid())
 	{
-		return GetWhite(); // “Ç‚İ‚İ‚É¸”s‚µ‚½‚Í”’’PFƒeƒNƒXƒ`ƒƒ‚ğ•Ô‚·
+		return GetWhite(); // èª­ã¿è¾¼ã¿ã«å¤±æ•—ã—ãŸæ™‚ã¯ç™½å˜è‰²ãƒ†ã‚¯ã‚¹ãƒãƒ£ã‚’è¿”ã™
 	}
 	return tex;
 }
@@ -151,7 +151,7 @@ ID3D12Resource* Texture2D::GetDefaultResource(size_t width, size_t height)
 	ID3D12Resource* buff = nullptr;
 	auto result = g_Engine->Device()->CreateCommittedResource(
 		&texHeapProp,
-		D3D12_HEAP_FLAG_NONE, //“Á‚Éw’è‚È‚µ
+		D3D12_HEAP_FLAG_NONE, //ç‰¹ã«æŒ‡å®šãªã—
 		&resDesc,
 		D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
 		nullptr,
@@ -180,7 +180,11 @@ D3D12_SHADER_RESOURCE_VIEW_DESC Texture2D::ViewDesc()
 	D3D12_SHADER_RESOURCE_VIEW_DESC desc = {};
 	desc.Format = m_pResource->GetDesc().Format;
 	desc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-	desc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D; //2DƒeƒNƒXƒ`ƒƒ
-	desc.Texture2D.MipLevels = 1; //ƒ~ƒbƒvƒ}ƒbƒv‚Íg—p‚µ‚È‚¢‚Ì‚Å1
+Texture2D::~Texture2D()
+{
+        m_pResource.Reset();
+}
+	desc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D; //2Dãƒ†ã‚¯ã‚¹ãƒãƒ£
+	desc.Texture2D.MipLevels = 1; //ãƒŸãƒƒãƒ—ãƒãƒƒãƒ—ã¯ä½¿ç”¨ã—ãªã„ã®ã§1
 	return desc;
 }

--- a/DirectX12/Texture2D.h
+++ b/DirectX12/Texture2D.h
@@ -9,20 +9,21 @@ class DescriptorHandle;
 class Texture2D
 {
 public:
-	static Texture2D* Get(std::string path); // string‚Åó‚¯æ‚Á‚½ƒpƒX‚©‚çƒeƒNƒXƒ`ƒƒ‚ğ“Ç‚İ‚Ş
-	static Texture2D* Get(std::wstring path); // wstring‚Åó‚¯æ‚Á‚½ƒpƒX‚©‚çƒeƒNƒXƒ`ƒƒ‚ğ“Ç‚İ‚Ş
-	static Texture2D* GetWhite(); // ”’‚Ì’PFƒeƒNƒXƒ`ƒƒ‚ğ¶¬‚·‚é
-	bool IsValid(); // ³í‚É“Ç‚İ‚Ü‚ê‚Ä‚¢‚é‚©‚Ç‚¤‚©‚ğ•Ô‚·
+        ~Texture2D();
+	static Texture2D* Get(std::string path); // stringã§å—ã‘å–ã£ãŸãƒ‘ã‚¹ã‹ã‚‰ãƒ†ã‚¯ã‚¹ãƒãƒ£ã‚’èª­ã¿è¾¼ã‚€
+	static Texture2D* Get(std::wstring path); // wstringã§å—ã‘å–ã£ãŸãƒ‘ã‚¹ã‹ã‚‰ãƒ†ã‚¯ã‚¹ãƒãƒ£ã‚’èª­ã¿è¾¼ã‚€
+	static Texture2D* GetWhite(); // ç™½ã®å˜è‰²ãƒ†ã‚¯ã‚¹ãƒãƒ£ã‚’ç”Ÿæˆã™ã‚‹
+	bool IsValid(); // æ­£å¸¸ã«èª­ã¿è¾¼ã¾ã‚Œã¦ã„ã‚‹ã‹ã©ã†ã‹ã‚’è¿”ã™
 
-	ID3D12Resource* Resource(); // ƒŠƒ\[ƒX‚ğ•Ô‚·
-	D3D12_SHADER_RESOURCE_VIEW_DESC ViewDesc(); // ƒVƒF[ƒ_[ƒŠƒ\[ƒXƒrƒ…[‚Ìİ’è‚ğ•Ô‚·
+	ID3D12Resource* Resource(); // ãƒªã‚½ãƒ¼ã‚¹ã‚’è¿”ã™
+	D3D12_SHADER_RESOURCE_VIEW_DESC ViewDesc(); // ã‚·ã‚§ãƒ¼ãƒ€ãƒ¼ãƒªã‚½ãƒ¼ã‚¹ãƒ“ãƒ¥ãƒ¼ã®è¨­å®šã‚’è¿”ã™
 
 private:
-	bool m_IsValid; // ³í‚É“Ç‚İ‚Ü‚ê‚Ä‚¢‚é‚©
+	bool m_IsValid; // æ­£å¸¸ã«èª­ã¿è¾¼ã¾ã‚Œã¦ã„ã‚‹ã‹
 	Texture2D(std::string path);
 	Texture2D(std::wstring path);
 	Texture2D(ID3D12Resource* buffer);
-	ComPtr<ID3D12Resource> m_pResource; // ƒŠƒ\[ƒX
+	ComPtr<ID3D12Resource> m_pResource; // ãƒªã‚½ãƒ¼ã‚¹
 	bool Load(std::string& path);
 	bool Load(std::wstring& path);
 


### PR DESCRIPTION
## Summary
- implement destructors for `Scene`, `DescriptorHeap`, `Texture2D`, `Particle`, `FluidSystem`, and `ConstantBuffer`
- free dynamically allocated resources like vertex/index buffers and descriptor handles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68886e255b0083329e80f493c60294d4