### PR TITLE
Fix descriptor range variable name in FluidSystem

### DIFF
--- a/DirectX12/FluidSystem.cpp
+++ b/DirectX12/FluidSystem.cpp
@@ -93,10 +93,10 @@ void FluidSystem::Init(ID3D12Device* device, DXGI_FORMAT rtvFormat,
 
 	// 描画用パイプライン生成
 	// ルートシグネチャ
-	CD3DX12_DESCRIPTOR_RANGE graRange;
-	range.Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0);
-	CD3DX12_ROOT_PARAMETER graRootParam[2];
-	graRootParam[0].InitAsDescriptorTable(1, &range, D3D12_SHADER_VISIBILITY_PIXEL);
+        CD3DX12_DESCRIPTOR_RANGE graRange;
+        graRange.Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0);
+        CD3DX12_ROOT_PARAMETER graRootParam[2];
+        graRootParam[0].InitAsDescriptorTable(1, &graRange, D3D12_SHADER_VISIBILITY_PIXEL);
 	graRootParam[1].InitAsConstantBufferView(0, 0, D3D12_SHADER_VISIBILITY_PIXEL);
 	CD3DX12_ROOT_SIGNATURE_DESC rsd(2, graRootParam, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT);
 	ComPtr<ID3DBlob> graBlob, graErr;


### PR DESCRIPTION
## Summary
- fix missing variable `range` in `FluidSystem.cpp` by using `graRange`

## Testing
- `g++ -std=c++20 -c DirectX12/FluidSystem.cpp -I./DirectX12` *(fails: wrl/client.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6888da8ed5288332a157c9fd80c986df