### PR TITLE
Add shared random float utility

### DIFF
--- a/DirectX12/FluidSystem.cpp
+++ b/DirectX12/FluidSystem.cpp
@@ -4,6 +4,7 @@
 #include <d3dcompiler.h>
 #include "Engine.h"
 #include "Camera.h"
+#include "RandomUtil.h"
 
 struct SPHParamsCB {
     float restDensity;

--- a/DirectX12/Particle.cpp
+++ b/DirectX12/Particle.cpp
@@ -1,15 +1,7 @@
 ﻿#include "Particle.h"
 #include "SharedStruct.h"
+#include "RandomUtil.h"
 
-#include <random>
-// 
-float RandFloat(float min, float max)
-{
-	static std::random_device rd;
-	static std::mt19937 gen(rd()); 
-	std::uniform_real_distribution<float> dist(min, max);
-	return dist(gen);
-}
 
 Particle::Particle(Camera* cam) : camera(cam) {
 	Init();

--- a/DirectX12/RandomUtil.h
+++ b/DirectX12/RandomUtil.h
@@ -1,0 +1,10 @@
+#pragma once
+#include <random>
+
+inline float RandFloat(float min, float max)
+{
+    static std::mt19937 gen{ std::random_device{}() };
+    std::uniform_real_distribution<float> dist(min, max);
+    return dist(gen);
+}
+


### PR DESCRIPTION
## Summary
- add `RandomUtil.h` containing a `RandFloat` helper implemented with `std::mt19937`
- remove the local random function from `Particle.cpp`
- include the new header in `Particle.cpp` and `FluidSystem.cpp`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68891c1b9dec8332815dc1175a67d1e0