### PR TITLE
Separate particle buffers for compute

### DIFF
--- a/DirectX12/FluidSystem.h
+++ b/DirectX12/FluidSystem.h
@@ -7,6 +7,7 @@
 #include <DirectXMath.h>
 #include "SharedStruct.h"
 #include "ConstantBuffer.h"
+#include <vector>
 
 
 class FluidSystem {
@@ -29,13 +30,15 @@ public:
 
 private:
     // CPU 側パーティクル配列
-    std::vector<ParticleMeta>     m_cpuParticles;
+    std::vector<Particle>         m_cpuParticles;
 
     // GPU 用バッファ (SRV/UAV共用)
-    ComPtr<ID3D12Resource>        m_particleBuffer;
+    ComPtr<ID3D12Resource>        m_particleBuffer; // simulation particles
+    ComPtr<ID3D12Resource>        m_metaBuffer;     // metadata for rendering
     ComPtr<ID3D12DescriptorHeap>  m_uavHeap;      // UAV を持つヒープ
     ComPtr<ID3D12DescriptorHeap>  m_graphicsSrvHeap; // SRV 用ヒープ
-    ComPtr<ID3D12Resource>        m_uploadHeap;
+    ComPtr<ID3D12Resource>        m_particleUpload;
+    ComPtr<ID3D12Resource>        m_metaUpload;
 
     // Compute 用定数バッファ
     ConstantBuffer*               m_sphParamCB = nullptr;

--- a/DirectX12/SharedStruct.h
+++ b/DirectX12/SharedStruct.h
@@ -39,10 +39,15 @@ struct ParticleVertex {
 	static const D3D12_INPUT_LAYOUT_DESC InputLayout;
 	static constexpr UINT InputElementCount = _countof(InputElements);
 };
+struct Particle {
+        DirectX::XMFLOAT3 position;
+        DirectX::XMFLOAT3 velocity;
+};
 
-// ƒƒ^ƒ{[ƒ‹—p‚Ì—±qî•ñ
+
+// ãƒ¡ã‚¿ãƒœãƒ¼ãƒ«ç”¨ã®ç²’å­æƒ…å ±
 struct ParticleMeta
 {
-	DirectX::XMFLOAT3 pos;   // ƒ[ƒ‹ƒh‹óŠÔˆÊ’u
-	float               r;    // ”¼Œa
+	DirectX::XMFLOAT3 pos;   // ãƒ¯ãƒ¼ãƒ«ãƒ‰ç©ºé–“ä½ç½®
+	float               r;    // åŠå¾„
 };


### PR DESCRIPTION
## Summary
- add `Particle` struct in shared C++ headers
- use `Particle` and `ParticleMeta` buffers in `FluidSystem`
- create descriptor heap with SRV and two UAVs for compute shader

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68891c3ac4bc833287c55a929ec38e35