### PR TITLE
Add meta buffer for FluidSystem

### DIFF
--- a/DirectX12/FluidSystem.h
+++ b/DirectX12/FluidSystem.h
@@ -33,6 +33,7 @@ private:
 
     // GPU 用バッファ (SRV/UAV共用)
     ComPtr<ID3D12Resource>        m_particleBuffer;
+    ComPtr<ID3D12Resource>        m_metaBuffer;  // ParticleMeta 用バッファ
     ComPtr<ID3D12DescriptorHeap>  m_uavHeap;      // UAV を持つヒープ
     ComPtr<ID3D12DescriptorHeap>  m_graphicsSrvHeap; // SRV 用ヒープ
     ComPtr<ID3D12Resource>        m_uploadHeap;


### PR DESCRIPTION
## Summary
- allocate an additional UAV buffer `m_metaBuffer`
- expand compute descriptor heap to hold SRV, particle UAV, and meta UAV
- expose the meta buffer in graphics SRV heap
- bind the meta buffer to root parameter `u1` during simulation
- read particle meta from this buffer during rendering

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68891c3cb998833294dc4a6ccf488f00