### PR TITLE
Handle CPU buffer transitions

### DIFF
--- a/DirectX12/FluidSystem.h
+++ b/DirectX12/FluidSystem.h
@@ -95,4 +95,6 @@ private:
 
     // Tracks whether meta buffer is currently in shader resource state
     bool m_metaInSrvState = false;
+    // Tracks whether particle buffer is currently in shader resource state
+    bool m_particleInSrvState = false;
 };


### PR DESCRIPTION
## Summary
- add particle state tracking
- transition particle/meta buffers to COPY_DEST before UpdateSubresources
- transition buffers back to SRV state for rendering
- bring particle buffer back to UAV when GPU sim resumes

## Testing
- `msbuild DirectX12.sln` *(fails: command not found)*
- `apt-get install -y msbuild` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_688b226d9e188332a8360ad73ccb8828