### PR TITLE
Handle compute PSO creation failure

### DIFF
--- a/DirectX12/ComputePipelineState.cpp
+++ b/DirectX12/ComputePipelineState.cpp
@@ -27,10 +27,10 @@ void ComputePipelineState::SetCS(const std::wstring& path) {
 }
 
 // 生成
-void ComputePipelineState::Create() {
+bool ComputePipelineState::Create() {
     if (!m_csBlob) {
         wprintf(L"[Error] Compute shader is not loaded.\n");
-        return;
+        return false;
     }
 
     // desc.CS は SetCS() で設定済みだが、安全のため再設定しておく
@@ -41,5 +41,7 @@ void ComputePipelineState::Create() {
 
     if (FAILED(hr)) {
         wprintf(L"Compute PSO生成失敗 0x%08X\n", hr);
+        return false;
     }
+    return true;
 }

--- a/DirectX12/ComputePipelineState.h
+++ b/DirectX12/ComputePipelineState.h
@@ -15,7 +15,7 @@ public:
     void SetRootSignature(ID3D12RootSignature* rs) { desc.pRootSignature = rs; }
     void SetDevice(ID3D12Device* device) { m_device = device; }
     void SetCS(const std::wstring& path);
-    void Create();
+    bool Create();
     ID3D12PipelineState* Get() const { return m_pso.Get(); }
 
 };

--- a/DirectX12/FluidSystem.cpp
+++ b/DirectX12/FluidSystem.cpp
@@ -94,12 +94,17 @@ void FluidSystem::Init(ID3D12Device* device, DXGI_FORMAT rtvFormat,
         m_computePS.SetDevice(device);
         m_computePS.SetRootSignature(m_computeRS.Get());
         m_computePS.SetCS(L"ParticleCS.cso");
-        m_computePS.Create();
+        bool computeOk = m_computePS.Create();
 
         m_buildGridPS.SetDevice(device);
         m_buildGridPS.SetRootSignature(m_computeRS.Get());
         m_buildGridPS.SetCS(L"BuildGridCS.cso");
-        m_buildGridPS.Create();
+        bool buildOk = m_buildGridPS.Create();
+
+        if (!computeOk || !buildOk) {
+                wprintf(L"[Warning] Compute PSO creation failed. Falling back to CPU simulation.\n");
+                m_useGpu = false;
+        }
 
 	// ---------------------------------------------------------------------
 	// Particle and meta buffers

--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@ The `DirectX12.vcxproj` assumes the include directories and library paths for th
 
 The `assets` folder contains sample resources (e.g. `korosuke.fbx` and `default.png`) used by the project.
 
-If precompiled shader objects (`*.cso`) are missing, the engine will now
+If precompiled shader objects (`*.cso`) are missing, the engine will try to
 compile the corresponding HLSL files at runtime using `D3DCompileFromFile`.
+Ensure that the `.cso` files exist or that the DirectX shader compiler DLLs are
+available so compilation can succeed at runtime.
 
 ## License
 


### PR DESCRIPTION
## Summary
- return bool from `ComputePipelineState::Create`
- check PSO creation results in `FluidSystem::Init`
- note shader compiler requirement for runtime compilation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b29b448fc8332962fc70dc773d4e4