### PR TITLE
Add fade transitions between scenes

### DIFF
--- a/DirectX12/FadeController.cpp
+++ b/DirectX12/FadeController.cpp
@@ -1,0 +1,103 @@
+#include "FadeController.h"
+#include "Engine.h"
+
+using namespace DirectX;
+
+FadeController::FadeController()
+{
+    Init();
+}
+
+bool FadeController::Init()
+{
+    struct Vertex { XMFLOAT3 pos; };
+    Vertex vertices[] = {
+        { {-1.f, -1.f, 0.f} },
+        { {-1.f,  1.f, 0.f} },
+        { { 1.f, -1.f, 0.f} },
+        { { 1.f,  1.f, 0.f} },
+    };
+    m_vertexBuffer = std::make_unique<VertexBuffer>(sizeof(vertices), sizeof(Vertex), vertices);
+    if (!m_vertexBuffer->IsValid()) return false;
+
+    for (size_t i = 0; i < Engine::FRAME_BUFFER_COUNT; ++i) {
+        m_constantBuffers[i] = std::make_unique<ConstantBuffer>(sizeof(XMFLOAT4));
+        if (!m_constantBuffers[i]->IsValid()) return false;
+    }
+
+    // simple root signature with one constant buffer
+    CD3DX12_ROOT_PARAMETER param; 
+    param.InitAsConstantBufferView(0);
+    D3D12_ROOT_SIGNATURE_DESC rsDesc = {};
+    rsDesc.NumParameters = 1;
+    rsDesc.pParameters = &param;
+    rsDesc.Flags = D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT;
+
+    m_rootSignature = std::make_unique<RootSignature>();
+    if (!m_rootSignature->Init(rsDesc)) return false;
+
+    m_pipelineState = std::make_unique<PipelineState>();
+    D3D12_INPUT_ELEMENT_DESC layout[] = {
+        { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
+    };
+    D3D12_INPUT_LAYOUT_DESC layoutDesc{ layout, 1 };
+    m_pipelineState->SetInputLayout(layoutDesc);
+    m_pipelineState->SetRootSignature(m_rootSignature->Get());
+    m_pipelineState->SetVS(L"FadeVS.cso");
+    m_pipelineState->SetPS(L"FadePS.cso");
+    m_pipelineState->Create(D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLESTRIP);
+    return m_pipelineState->IsValid();
+}
+
+void FadeController::StartFadeOut(float duration)
+{
+    m_fadeOut = true;
+    m_active = true;
+    m_duration = duration;
+    m_timer = 0.0f;
+    m_alpha = 0.0f;
+}
+
+void FadeController::StartFadeIn(float duration)
+{
+    m_fadeOut = false;
+    m_active = true;
+    m_duration = duration;
+    m_timer = 0.0f;
+    m_alpha = 1.0f;
+}
+
+void FadeController::Update(float dt)
+{
+    if (!m_active) return;
+    m_timer += dt;
+    float t = (m_duration > 0.0f) ? m_timer / m_duration : 1.0f;
+    if (t >= 1.0f) {
+        t = 1.0f;
+        m_active = false;
+    }
+    if (m_fadeOut) {
+        m_alpha = t;
+    } else {
+        m_alpha = 1.0f - t;
+    }
+}
+
+void FadeController::Render()
+{
+    if (m_alpha <= 0.0f) return;
+    auto cmd = g_Engine->CommandList();
+    UINT idx = g_Engine->CurrentBackBufferIndex();
+    auto colorPtr = m_constantBuffers[idx]->GetPtr<XMFLOAT4>();
+    *colorPtr = XMFLOAT4(0.f, 0.f, 0.f, m_alpha);
+
+    cmd->SetGraphicsRootSignature(m_rootSignature->Get());
+    cmd->SetPipelineState(m_pipelineState->Get());
+    cmd->SetGraphicsRootConstantBufferView(0, m_constantBuffers[idx]->GetAddress());
+
+    auto vbv = m_vertexBuffer->View();
+    cmd->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+    cmd->IASetVertexBuffers(0, 1, &vbv);
+    cmd->DrawInstanced(4, 1, 0, 0);
+}
+

--- a/DirectX12/FadeController.h
+++ b/DirectX12/FadeController.h
@@ -1,0 +1,36 @@
+#pragma once
+#include "VertexBuffer.h"
+#include "RootSignature.h"
+#include "PipelineState.h"
+#include "ConstantBuffer.h"
+#include <string>
+#include <memory>
+#include <DirectXMath.h>
+
+class FadeController
+{
+public:
+    FadeController();
+    void StartFadeOut(float duration = 1.0f);
+    void StartFadeIn(float duration = 1.0f);
+    void Update(float dt);
+    void Render();
+
+    bool IsFading() const { return m_active; }
+    bool IsFadeOutComplete() const { return !m_active && m_fadeOut && m_alpha >= 1.0f; }
+
+private:
+    bool Init();
+
+    std::unique_ptr<VertexBuffer> m_vertexBuffer;
+    std::unique_ptr<RootSignature> m_rootSignature;
+    std::unique_ptr<PipelineState> m_pipelineState;
+    std::unique_ptr<ConstantBuffer> m_constantBuffers[Engine::FRAME_BUFFER_COUNT];
+
+    float m_alpha = 0.0f;
+    bool  m_active = false;
+    bool  m_fadeOut = false;
+    float m_duration = 1.0f;
+    float m_timer = 0.0f;
+};
+

--- a/DirectX12/FadePS.hlsl
+++ b/DirectX12/FadePS.hlsl
@@ -1,0 +1,9 @@
+cbuffer FadeParam : register(b0)
+{
+    float4 Color;
+};
+
+float4 main() : SV_TARGET
+{
+    return Color;
+}

--- a/DirectX12/FadeVS.hlsl
+++ b/DirectX12/FadeVS.hlsl
@@ -1,0 +1,16 @@
+struct VSInput
+{
+    float3 pos : POSITION;
+};
+
+struct VSOutput
+{
+    float4 svpos : SV_POSITION;
+};
+
+VSOutput main(VSInput input)
+{
+    VSOutput o;
+    o.svpos = float4(input.pos, 1.0f);
+    return o;
+}

--- a/DirectX12/SceneManager.cpp
+++ b/DirectX12/SceneManager.cpp
@@ -3,50 +3,63 @@
 
 void SceneManager::RegisterScene(const std::string& name, SceneFactory factory)
 {
-	m_Registry[name] = factory;
+    m_Registry[name] = factory;
 }
 
 void SceneManager::ChangeScene(const std::string& name)
 {
-	auto it = m_Registry.find(name);
-	// ’†g‚ª‚ ‚é‚È‚ç
-	if (it != m_Registry.end())
-	{
-		if (!m_SceneStack.empty()) {
-			m_SceneStack.pop();
-		}
-		m_SceneStack.push(it->second());
-	}
+    if (m_SceneStack.empty()) {
+        auto it = m_Registry.find(name);
+        if (it != m_Registry.end()) {
+            m_SceneStack.push(it->second());
+        }
+    } else {
+        m_pendingScene = name;
+        m_fade.StartFadeOut();
+    }
 }
 
 void SceneManager::PushScene(const std::string& name)
 {
-	auto it = m_Registry.find(name);
-	if (it != m_Registry.end()) {
-		m_SceneStack.push(it->second());
-	}
+    auto it = m_Registry.find(name);
+    if (it != m_Registry.end()) {
+        m_SceneStack.push(it->second());
+    }
 }
-
 
 void SceneManager::PopScene()
 {
-	if (!m_SceneStack.empty()) {
-		m_SceneStack.pop();
-	}
+    if (!m_SceneStack.empty()) {
+        m_SceneStack.pop();
+    }
 }
-
 
 void SceneManager::Update(float deltaTime)
 {
-	if (!m_SceneStack.empty()) {
-		m_SceneStack.top()->Update(deltaTime);
-	}
-}
+    m_fade.Update(deltaTime);
 
+    if (!m_SceneStack.empty()) {
+        m_SceneStack.top()->Update(deltaTime);
+    }
+
+    if (!m_pendingScene.empty() && m_fade.IsFadeOutComplete()) {
+        auto it = m_Registry.find(m_pendingScene);
+        if (it != m_Registry.end()) {
+            if (!m_SceneStack.empty()) {
+                m_SceneStack.pop();
+            }
+            m_SceneStack.push(it->second());
+        }
+        m_pendingScene.clear();
+        m_fade.StartFadeIn();
+    }
+}
 
 void SceneManager::Render()
 {
-	if (!m_SceneStack.empty()) {
-		m_SceneStack.top()->Draw();
-	}
+    if (!m_SceneStack.empty()) {
+        m_SceneStack.top()->Draw();
+    }
+    m_fade.Render();
 }
+

--- a/DirectX12/SceneManager.h
+++ b/DirectX12/SceneManager.h
@@ -5,6 +5,7 @@
 #include <stack>
 #include <functional>
 #include "BaseScene.h"
+#include "FadeController.h"
 
 class SceneManager
 {
@@ -13,6 +14,10 @@ private:
 
     std::map<std::string, SceneFactory> m_Registry;
     std::stack<std::unique_ptr<BaseScene>> m_SceneStack;
+
+    FadeController m_fade;
+    std::string m_pendingScene;
+
 public:
     void RegisterScene(const std::string& name, SceneFactory factory);
     void ChangeScene(const std::string& name);
@@ -22,5 +27,4 @@ public:
     void Update(float deltaTime);
     void Render();
 };
-
 


### PR DESCRIPTION
## Summary
- implement `FadeController` for simple fullscreen fade effect
- integrate `FadeController` into `SceneManager`
- add HLSL shaders for fade rendering

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b662703808332ac01db75fcb85fad