### PR TITLE
Fix missing FadeController build entries

### DIFF
--- a/DirectX12/DirectX12.vcxproj
+++ b/DirectX12/DirectX12.vcxproj
@@ -170,6 +170,7 @@
     <ClCompile Include="RootSignature.cpp" />
     <ClCompile Include="Scene.cpp" />
     <ClCompile Include="SceneManager.cpp" />
+    <ClCompile Include="FadeController.cpp" />
     <ClCompile Include="SharedStruct.cpp" />
     <ClCompile Include="SphereMeshGenerator.cpp" />
     <ClCompile Include="Texture2D.cpp" />
@@ -200,6 +201,7 @@
     <ClInclude Include="RootSignature.h" />
     <ClInclude Include="Scene.h" />
     <ClInclude Include="SceneManager.h" />
+    <ClInclude Include="FadeController.h" />
     <ClInclude Include="SharedStruct.h" />
     <ClInclude Include="SphereMeshGenerator.h" />
     <ClInclude Include="SpatialGrid.h" />

--- a/DirectX12/DirectX12.vcxproj.filters
+++ b/DirectX12/DirectX12.vcxproj.filters
@@ -93,6 +93,9 @@
     <ClCompile Include="SceneManager.cpp">
       <Filter>ソース ファイル\Game</Filter>
     </ClCompile>
+    <ClCompile Include="FadeController.cpp">
+      <Filter>ソース ファイル\Game</Filter>
+    </ClCompile>
     <ClCompile Include="Scene.cpp">
       <Filter>ソース ファイル\Game\Scene</Filter>
     </ClCompile>
@@ -178,6 +181,9 @@
       <Filter>ヘッダー ファイル\Game\Scene</Filter>
     </ClInclude>
     <ClInclude Include="SceneManager.h">
+      <Filter>ヘッダー ファイル\Game</Filter>
+    </ClInclude>
+    <ClInclude Include="FadeController.h">
       <Filter>ヘッダー ファイル\Game</Filter>
     </ClInclude>
     <ClInclude Include="Scene.h">


### PR DESCRIPTION
## Summary
- add `FadeController.cpp` and `FadeController.h` to project sources

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b67f7f2708332b800fd93b77fb35a