### PR TITLE
Fix fade overlay depth test

### DIFF
--- a/DirectX12/FadeController.cpp
+++ b/DirectX12/FadeController.cpp
@@ -36,7 +36,7 @@ bool FadeController::Init()
     m_rootSignature = std::make_unique<RootSignature>();
     if (!m_rootSignature->Init(rsDesc)) return false;
 
-    m_pipelineState = std::make_unique<PipelineState>();
+    m_pipelineState = std::make_unique<ParticlePipelineState>();
     D3D12_INPUT_ELEMENT_DESC layout[] = {
         { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 }
     };

--- a/DirectX12/FadeController.h
+++ b/DirectX12/FadeController.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "VertexBuffer.h"
 #include "RootSignature.h"
-#include "PipelineState.h"
+#include "ParticlePipelineState.h"
 #include "ConstantBuffer.h"
 #include <string>
 #include <memory>
@@ -25,7 +25,7 @@ private:
 
     std::unique_ptr<VertexBuffer> m_vertexBuffer;
     std::unique_ptr<RootSignature> m_rootSignature;
-    std::unique_ptr<PipelineState> m_pipelineState;
+    std::unique_ptr<ParticlePipelineState> m_pipelineState;
     std::unique_ptr<ConstantBuffer> m_constantBuffers[Engine::FRAME_BUFFER_COUNT];
 
     float m_alpha = 0.0f;


### PR DESCRIPTION
## Summary
- disable depth testing for fade overlay by using `ParticlePipelineState`
- fade now renders over scene objects

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b6d3360b88332a561342229ce9e89