### PR TITLE
Add test cube actor to GameScene

### DIFF
--- a/DirectX12/DirectX12.vcxproj
+++ b/DirectX12/DirectX12.vcxproj
@@ -166,6 +166,7 @@
     <ClCompile Include="MetaBallPipelineState.cpp" />
     <ClCompile Include="Object.cpp" />
     <ClCompile Include="Particle.cpp" />
+    <ClCompile Include="TestCube.cpp" />
     <ClCompile Include="PipelineState.cpp" />
     <ClCompile Include="ParticlePipelineState.cpp" />
     <ClCompile Include="RootSignature.cpp" />
@@ -198,6 +199,7 @@
     <ClInclude Include="MetaBallPipelineState.h" />
     <ClInclude Include="Object.h" />
     <ClInclude Include="Particle.h" />
+    <ClInclude Include="TestCube.h" />
     <ClInclude Include="PipelineState.h" />
     <ClInclude Include="ParticlePipelineState.h" />
     <ClInclude Include="RootSignature.h" />

--- a/DirectX12/DirectX12.vcxproj.filters
+++ b/DirectX12/DirectX12.vcxproj.filters
@@ -126,6 +126,9 @@
     <ClCompile Include="Particle.cpp">
       <Filter>ソース ファイル\Game\Object</Filter>
     </ClCompile>
+    <ClCompile Include="TestCube.cpp">
+      <Filter>ソース ファイル\Game\Object</Filter>
+    </ClCompile>
     <ClCompile Include="Camera.cpp">
       <Filter>ソース ファイル\Game</Filter>
     </ClCompile>
@@ -211,6 +214,9 @@
       <Filter>ヘッダー ファイル\Game\Object</Filter>
     </ClInclude>
     <ClInclude Include="Particle.h">
+      <Filter>ヘッダー ファイル\Game\Object</Filter>
+    </ClInclude>
+    <ClInclude Include="TestCube.h">
       <Filter>ヘッダー ファイル\Game\Object</Filter>
     </ClInclude>
     <ClInclude Include="ParticlePipelineState.h">

--- a/DirectX12/GameScene.cpp
+++ b/DirectX12/GameScene.cpp
@@ -4,6 +4,7 @@
 #include <DirectXMath.h>
 #include "SharedStruct.h"
 #include "App.h"
+#include "TestCube.h" // テスト用立方体
 
 #include <windows.h>
 
@@ -44,6 +45,9 @@ bool GameScene::Init() {
         m_fluid.Init(device, rtvFormat, maxParticles, 0);
         m_fluid.SetSpatialCellSize(0.1f); // 計算範囲
         m_fluid.UseGPU(true); // GPU でシミュレーションをするかどうか
+
+        // テスト用の立方体をシーンに追加
+        Spawn<TestCube>();
 
 
 	return true;

--- a/DirectX12/TestCube.cpp
+++ b/DirectX12/TestCube.cpp
@@ -1,0 +1,116 @@
+#include "TestCube.h"
+
+#include <vector>
+
+using namespace DirectX;
+
+TestCube::TestCube() {
+    Init();
+}
+
+TestCube::~TestCube() {
+    delete m_vertexBuffer;
+    delete m_indexBuffer;
+    for (auto& cb : m_constantBuffer) {
+        delete cb;
+    }
+    delete m_rootSignature;
+    delete m_pipelineState;
+}
+
+bool TestCube::Init() {
+    // 立方体の頂点データ（位置・法線・UV・色）
+    std::vector<Vertex> vertices = {
+        // +X 面
+        {{ 0.5f,-0.5f,-0.5f},{ 1,0,0},{0,1},{0,0,0},{1,1,1,1}},
+        {{ 0.5f, 0.5f,-0.5f},{ 1,0,0},{0,0},{0,0,0},{1,1,1,1}},
+        {{ 0.5f, 0.5f, 0.5f},{ 1,0,0},{1,0},{0,0,0},{1,1,1,1}},
+        {{ 0.5f,-0.5f, 0.5f},{ 1,0,0},{1,1},{0,0,0},{1,1,1,1}},
+        // -X 面
+        {{-0.5f,-0.5f, 0.5f},{-1,0,0},{0,1},{0,0,0},{1,1,1,1}},
+        {{-0.5f, 0.5f, 0.5f},{-1,0,0},{0,0},{0,0,0},{1,1,1,1}},
+        {{-0.5f, 0.5f,-0.5f},{-1,0,0},{1,0},{0,0,0},{1,1,1,1}},
+        {{-0.5f,-0.5f,-0.5f},{-1,0,0},{1,1},{0,0,0},{1,1,1,1}},
+        // +Y 面
+        {{-0.5f, 0.5f,-0.5f},{0,1,0},{0,1},{0,0,0},{1,1,1,1}},
+        {{-0.5f, 0.5f, 0.5f},{0,1,0},{0,0},{0,0,0},{1,1,1,1}},
+        {{ 0.5f, 0.5f, 0.5f},{0,1,0},{1,0},{0,0,0},{1,1,1,1}},
+        {{ 0.5f, 0.5f,-0.5f},{0,1,0},{1,1},{0,0,0},{1,1,1,1}},
+        // -Y 面
+        {{-0.5f,-0.5f, 0.5f},{0,-1,0},{0,1},{0,0,0},{1,1,1,1}},
+        {{-0.5f,-0.5f,-0.5f},{0,-1,0},{0,0},{0,0,0},{1,1,1,1}},
+        {{ 0.5f,-0.5f,-0.5f},{0,-1,0},{1,0},{0,0,0},{1,1,1,1}},
+        {{ 0.5f,-0.5f, 0.5f},{0,-1,0},{1,1},{0,0,0},{1,1,1,1}},
+        // +Z 面
+        {{ 0.5f,-0.5f, 0.5f},{0,0,1},{0,1},{0,0,0},{1,1,1,1}},
+        {{ 0.5f, 0.5f, 0.5f},{0,0,1},{0,0},{0,0,0},{1,1,1,1}},
+        {{-0.5f, 0.5f, 0.5f},{0,0,1},{1,0},{0,0,0},{1,1,1,1}},
+        {{-0.5f,-0.5f, 0.5f},{0,0,1},{1,1},{0,0,0},{1,1,1,1}},
+        // -Z 面
+        {{-0.5f,-0.5f,-0.5f},{0,0,-1},{0,1},{0,0,0},{1,1,1,1}},
+        {{-0.5f, 0.5f,-0.5f},{0,0,-1},{0,0},{0,0,0},{1,1,1,1}},
+        {{ 0.5f, 0.5f,-0.5f},{0,0,-1},{1,0},{0,0,0},{1,1,1,1}},
+        {{ 0.5f,-0.5f,-0.5f},{0,0,-1},{1,1},{0,0,0},{1,1,1,1}},
+    };
+
+    uint32_t indices[] = {
+        0,1,2, 0,2,3,
+        4,5,6, 4,6,7,
+        8,9,10, 8,10,11,
+        12,13,14, 12,14,15,
+        16,17,18, 16,18,19,
+        20,21,22, 20,22,23
+    };
+
+    m_vertexBuffer = new VertexBuffer(sizeof(Vertex)*vertices.size(), sizeof(Vertex), vertices.data());
+    if (!m_vertexBuffer->IsValid()) return false;
+
+    m_indexBuffer = new IndexBuffer(sizeof(indices), indices);
+    if (!m_indexBuffer->IsValid()) return false;
+
+    for (int i = 0; i < Engine::FRAME_BUFFER_COUNT; ++i) {
+        m_constantBuffer[i] = new ConstantBuffer(sizeof(Transform));
+        auto ptr = m_constantBuffer[i]->GetPtr<Transform>();
+        ptr->World = XMMatrixIdentity();
+        ptr->View = XMMatrixIdentity();
+        ptr->Proj = XMMatrixIdentity();
+    }
+
+    m_rootSignature = new RootSignature();
+    if (!m_rootSignature->IsValid()) return false;
+
+    m_pipelineState = new PipelineState();
+    m_pipelineState->SetInputLayout(Vertex::InputLayout);
+    m_pipelineState->SetRootSignature(m_rootSignature->Get());
+    m_pipelineState->SetVS(L"SimpleVS.cso");
+    m_pipelineState->SetPS(L"SimplePS.cso");
+    m_pipelineState->Create(D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE);
+    if (!m_pipelineState->IsValid()) return false;
+
+    return true;
+}
+
+void TestCube::Update(float deltaTime) {
+    m_rotation.y += deltaTime; // 単純にY軸回転
+    auto current = g_Engine->CurrentBackBufferIndex();
+    auto camera = g_Engine->GetObj<Camera>("Camera");
+    auto ptr = m_constantBuffer[current]->GetPtr<Transform>();
+    ptr->World = XMMatrixRotationRollPitchYaw(m_rotation.x, m_rotation.y, m_rotation.z);
+    ptr->View = camera->GetViewMatrix();
+    ptr->Proj = camera->GetProjMatrix();
+}
+
+void TestCube::Render(ID3D12GraphicsCommandList* cmd) {
+    auto current = g_Engine->CurrentBackBufferIndex();
+    auto vbv = m_vertexBuffer->View();
+    auto ibv = m_indexBuffer->View();
+
+    cmd->SetGraphicsRootSignature(m_rootSignature->Get());
+    cmd->SetPipelineState(m_pipelineState->Get());
+    cmd->SetGraphicsRootConstantBufferView(0, m_constantBuffer[current]->GetAddress());
+    cmd->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+    cmd->IASetVertexBuffers(0,1,&vbv);
+    cmd->IASetIndexBuffer(&ibv);
+    cmd->DrawIndexedInstanced(36,1,0,0,0);
+}
+

--- a/DirectX12/TestCube.h
+++ b/DirectX12/TestCube.h
@@ -1,0 +1,40 @@
+#pragma once
+// テスト用のシンプルな立方体を描画するアクタ
+// 日本語コメントで分かりやすく説明する
+
+#include "IActor.h"
+#include "VertexBuffer.h"
+#include "IndexBuffer.h"
+#include "ConstantBuffer.h"
+#include "RootSignature.h"
+#include "PipelineState.h"
+#include "Camera.h"
+#include "SharedStruct.h"
+#include "Engine.h"
+
+#include <DirectXMath.h>
+
+// テスト用の立方体を生成して描画するクラス
+class TestCube : public IActor {
+public:
+    TestCube();
+    ~TestCube();
+
+    // 初期化処理
+    bool Init();
+
+    // 毎フレームの更新処理
+    void Update(float deltaTime) override;
+
+    // 描画処理
+    void Render(ID3D12GraphicsCommandList* cmd) override;
+
+private:
+    VertexBuffer* m_vertexBuffer = nullptr;        // 頂点データ
+    IndexBuffer*  m_indexBuffer  = nullptr;        // インデックスデータ
+    ConstantBuffer* m_constantBuffer[Engine::FRAME_BUFFER_COUNT] = {}; // 行列用CB
+    RootSignature* m_rootSignature = nullptr;      // ルートシグネチャ
+    PipelineState* m_pipelineState = nullptr;      // パイプラインステート
+    DirectX::XMFLOAT3 m_rotation = {0.f, 0.f, 0.f}; // 回転角
+};
+


### PR DESCRIPTION
## Summary
- spawn a simple rotating cube in `GameScene`
- add `TestCube` actor implementation
- include new cube actor in project files

## Testing
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0fd7d239c8332889304ab1c4b47e0