### PR TITLE
Fix invisible cube and fluid

### DIFF
--- a/DirectX12/FluidSystem.h
+++ b/DirectX12/FluidSystem.h
@@ -85,7 +85,8 @@ private:
     float m_dragDepth = 0.0f;
 
 
-	bool m_useScreenSpace = true; // スクリーンスペースエフェクトを使うか
+        // 初期状態ではスクリーンスペースエフェクトを無効化
+        bool m_useScreenSpace = false;
 
     // 低解像度（1/2）蓄積RT と ブラー用RT
     Microsoft::WRL::ComPtr<ID3D12Resource> m_accumTex; // R16_FLOAT or R32_FLOAT

--- a/DirectX12/SimplePS.hlsl
+++ b/DirectX12/SimplePS.hlsl
@@ -2,13 +2,17 @@ struct VSOutput
 {
     float4 svpos : SV_POSITION;
     float4 color : COLOR;
-    float2 uv : TEXCOORD;
+    float2 uv    : TEXCOORD;
 };
 
-SamplerState smp : register(s0); // �T���v���[
-Texture2D _MainTex : register(t0); // �e�N�X�`��
+SamplerState smp    : register(s0);
+Texture2D    _MainTex : register(t0);
 
 float4 pixel(VSOutput input) : SV_TARGET
 {
-    return _MainTex.Sample(smp, input.uv);
+    // テクスチャがバインドされていない場合は0が返るため、
+    // アルファ値を用いて頂点カラーへフォールバックする
+    float4 tex = _MainTex.Sample(smp, input.uv);
+    return lerp(input.color, tex, tex.a);
 }
+


### PR DESCRIPTION
## Summary
- Use vertex color when no texture is bound so cube becomes visible
- Disable screen-space fluid rendering by default for clearer display

## Testing
- `ctest` *(No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68c102018abc83328269150b37bc5122