### PR TITLE
Fix fluid rendering by keeping particle SRV handle

### DIFF
--- a/DirectX12/FluidSystem.cpp
+++ b/DirectX12/FluidSystem.cpp
@@ -734,9 +734,9 @@ void FluidSystem::DestroySSAResources()
 	m_accumRTV = {};
 	m_blurRTV = {};
 
-	m_accumSRV = {};
-	m_blurSRV = {};
-	m_particleSRV = {};
+        m_accumSRV = {};
+        m_blurSRV = {};
+        // m_particleSRV はグラフィックス用ヒープにあるためここではリセットしない
 }
 
 void FluidSystem::CreateSSAResources(ID3D12Device* device, DXGI_FORMAT mainRTFormat, UINT viewW, UINT viewH)


### PR DESCRIPTION
## Summary
- Avoid resetting particle SRV handle when recreating screen-space resources
- Add explanation comment in Japanese

## Testing
- `cmake .` *(fails: The source directory does not appear to contain CMakeLists.txt)*

------
https://chatgpt.com/codex/tasks/task_e_68c123b3cd788332b8585772bbdb4e3d