### PR TITLE
Fix shader search for fluid pipeline

### DIFF
--- a/DirectX12/MetaBallPipelineState.cpp
+++ b/DirectX12/MetaBallPipelineState.cpp
@@ -1,8 +1,114 @@
 #include "MetaBallPipelineState.h"
 #include <d3dcompiler.h>
 #include "d3dx12.h"
+#include <Windows.h>
+#include <filesystem>
+#include <vector>
+#include <string>
+#include <cstdio>
 
 namespace graphics {
+
+    namespace
+    {
+        // 実行ファイルのあるディレクトリを取得する
+        std::filesystem::path GetExecutableDirectory()
+        {
+            wchar_t path[MAX_PATH] = {};
+            DWORD length = GetModuleFileNameW(nullptr, path, MAX_PATH);
+            if (length == 0 || length == MAX_PATH)
+            {
+                return {};
+            }
+            return std::filesystem::path(path).parent_path();
+        }
+
+        // シェーダーファイルを探索して最初に見つかったパスを返す
+        std::wstring ResolveShaderPath(const std::wstring& fileName)
+        {
+            std::vector<std::filesystem::path> searchDirectories;
+
+            // まずは現在の作業ディレクトリ
+            searchDirectories.push_back(std::filesystem::current_path());
+
+            // さらに実行ファイルのディレクトリとその親ディレクトリを順番に確認する
+            std::filesystem::path exeDir = GetExecutableDirectory();
+            for (int i = 0; !exeDir.empty() && i < 5; ++i)
+            {
+                searchDirectories.push_back(exeDir);
+                exeDir = exeDir.parent_path();
+            }
+
+            for (const auto& base : searchDirectories)
+            {
+                std::filesystem::path candidate = base / fileName;
+                if (std::filesystem::exists(candidate))
+                {
+                    return candidate.wstring();
+                }
+            }
+
+            return L"";
+        }
+
+        // CSO 読み込み→失敗時 HLSL コンパイルの順でシェーダーを確保する
+        bool LoadOrCompileShader(
+            const std::wstring& csoName,
+            const std::wstring& hlslName,
+            const char* entryPoint,
+            const char* shaderModel,
+            ComPtr<ID3DBlob>& outBlob)
+        {
+            std::wstring csoPath = ResolveShaderPath(csoName);
+            if (!csoPath.empty())
+            {
+                HRESULT hr = D3DReadFileToBlob(csoPath.c_str(), &outBlob);
+                if (SUCCEEDED(hr))
+                {
+                    return true;
+                }
+            }
+
+            std::wstring hlslPath = ResolveShaderPath(hlslName);
+            if (hlslPath.empty())
+            {
+                wprintf(L"FluidSystem: シェーダーファイル %ls が見つかりません\n", hlslName.c_str());
+                return false;
+            }
+
+            UINT flags = D3DCOMPILE_ENABLE_STRICTNESS;
+#ifdef _DEBUG
+            flags |= D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
+#endif
+
+            ComPtr<ID3DBlob> err;
+            HRESULT hr = D3DCompileFromFile(
+                hlslPath.c_str(),
+                nullptr,
+                nullptr,
+                entryPoint,
+                shaderModel,
+                flags,
+                0,
+                &outBlob,
+                &err);
+
+            if (FAILED(hr))
+            {
+                if (err)
+                {
+                    printf("FluidSystem: シェーダーコンパイルに失敗しました -> %s\n", static_cast<const char*>(err->GetBufferPointer()));
+                }
+                else
+                {
+                    wprintf(L"FluidSystem: シェーダー %ls のコンパイルに失敗しました (HRESULT=0x%08X)\n", hlslPath.c_str(), hr);
+                }
+                return false;
+            }
+
+            return true;
+        }
+    }
 
     void MetaBallPipeline::CreateRootSignature(
         ID3D12Device* device,
@@ -38,32 +144,18 @@ namespace graphics {
         DXGI_FORMAT rtvFormat,
         ComPtr<ID3D12PipelineState>& outPSO)
     {
-        // シェーダーコンパイル
+        // メタボール描画用シェーダーを読み込み（失敗時はその場でコンパイルを試みる）
         ComPtr<ID3DBlob> vsBlob;
-        HRESULT hr = D3DReadFileToBlob(L"MetaBallVS.cso", &vsBlob);
-        if (FAILED(hr)) {
-            UINT flags = D3DCOMPILE_ENABLE_STRICTNESS;
-#ifdef _DEBUG
-            flags |= D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
-#endif
-            ComPtr<ID3DBlob> err;
-            hr = D3DCompileFromFile(L"MetaBallVS.hlsl", nullptr, nullptr, "main", "vs_5_0", flags, 0, &vsBlob, &err);
-            if (FAILED(hr)) return;
+        if (!LoadOrCompileShader(L"MetaBallVS.cso", L"MetaBallVS.hlsl", "main", "vs_5_0", vsBlob))
+        {
+            return;
         }
 
         ComPtr<ID3DBlob> psBlob;
-        hr = D3DReadFileToBlob(L"MetaBallPS.cso", &psBlob);
-        if (FAILED(hr)) {
-            UINT flags = D3DCOMPILE_ENABLE_STRICTNESS;
-#ifdef _DEBUG
-            flags |= D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
-#endif
-            ComPtr<ID3DBlob> err;
-            hr = D3DCompileFromFile(L"MetaBallPS.hlsl", nullptr, nullptr, "main", "ps_5_0", flags, 0, &psBlob, &err);
-            if (FAILED(hr)) return;
+        if (!LoadOrCompileShader(L"MetaBallPS.cso", L"MetaBallPS.hlsl", "main", "ps_5_0", psBlob))
+        {
+            return;
         }
-        
-
 
         // PSO 設定
         D3D12_GRAPHICS_PIPELINE_STATE_DESC desc = {};


### PR DESCRIPTION
## Summary
- allow MetaBall shaders to be located relative to the executable or current working directory
- add logging for missing or failed shader compilation in the fluid rendering pipeline

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d39d7ab1c8833291ae427768dd1c92