### PR TITLE
Refactor fluid system with CPU/GPU pipeline

### DIFF
--- a/DirectX12/DescriptorHeap.cpp
+++ b/DirectX12/DescriptorHeap.cpp
@@ -18,7 +18,7 @@ DescriptorHeap::DescriptorHeap()
 
 	auto device = g_Engine->Device();
 
-	// ƒfƒBƒXƒNƒŠƒvƒ^ƒq[ƒv‚ğ¶¬
+	// ãƒ‡ã‚£ã‚¹ã‚¯ãƒªãƒ—ã‚¿ãƒ’ãƒ¼ãƒ—ã‚’ç”Ÿæˆ
 	auto hr = device->CreateDescriptorHeap(
 		&desc,
 		IID_PPV_ARGS(m_pHeap.ReleaseAndGetAddressOf()));
@@ -29,7 +29,7 @@ DescriptorHeap::DescriptorHeap()
 		return;
 	}
 
-	m_IncrementSize = device->GetDescriptorHandleIncrementSize(desc.Type); // ƒfƒBƒXƒNƒŠƒvƒ^ƒq[ƒv1ŒÂ‚Ìƒƒ‚ƒŠƒTƒCƒY‚ğ•Ô‚·
+	m_IncrementSize = device->GetDescriptorHandleIncrementSize(desc.Type); // ãƒ‡ã‚£ã‚¹ã‚¯ãƒªãƒ—ã‚¿ãƒ’ãƒ¼ãƒ—1å€‹ã®ãƒ¡ãƒ¢ãƒªã‚µã‚¤ã‚ºã‚’è¿”ã™
 	m_IsValid = true;
 }
 
@@ -48,11 +48,11 @@ DescriptorHandle* DescriptorHeap::Register(Texture2D* texture)
 
 	DescriptorHandle* pHandle = new DescriptorHandle();
 
-	auto handleCPU = m_pHeap->GetCPUDescriptorHandleForHeapStart(); // ƒfƒBƒXƒNƒŠƒvƒ^ƒq[ƒv‚ÌÅ‰‚ÌƒAƒhƒŒƒX
-	handleCPU.ptr += m_IncrementSize * count; // Å‰‚ÌƒAƒhƒŒƒX‚©‚çcount”Ô–Ú‚ª¡‰ñ’Ç‰Á‚³‚ê‚½ƒŠƒ\[ƒX‚Ìƒnƒ“ƒhƒ‹
+	auto handleCPU = m_pHeap->GetCPUDescriptorHandleForHeapStart(); // ãƒ‡ã‚£ã‚¹ã‚¯ãƒªãƒ—ã‚¿ãƒ’ãƒ¼ãƒ—ã®æœ€åˆã®ã‚¢ãƒ‰ãƒ¬ã‚¹
+	handleCPU.ptr += m_IncrementSize * count; // æœ€åˆã®ã‚¢ãƒ‰ãƒ¬ã‚¹ã‹ã‚‰countç•ªç›®ãŒä»Šå›è¿½åŠ ã•ã‚ŒãŸãƒªã‚½ãƒ¼ã‚¹ã®ãƒãƒ³ãƒ‰ãƒ«
 
-	auto handleGPU = m_pHeap->GetGPUDescriptorHandleForHeapStart(); // ƒfƒBƒXƒNƒŠƒvƒ^ƒq[ƒv‚ÌÅ‰‚ÌƒAƒhƒŒƒX
-	handleGPU.ptr += m_IncrementSize * count; // Å‰‚ÌƒAƒhƒŒƒX‚©‚çcount”Ô–Ú‚ª¡‰ñ’Ç‰Á‚³‚ê‚½ƒŠƒ\[ƒX‚Ìƒnƒ“ƒhƒ‹
+	auto handleGPU = m_pHeap->GetGPUDescriptorHandleForHeapStart(); // ãƒ‡ã‚£ã‚¹ã‚¯ãƒªãƒ—ã‚¿ãƒ’ãƒ¼ãƒ—ã®æœ€åˆã®ã‚¢ãƒ‰ãƒ¬ã‚¹
+	handleGPU.ptr += m_IncrementSize * count; // æœ€åˆã®ã‚¢ãƒ‰ãƒ¬ã‚¹ã‹ã‚‰countç•ªç›®ãŒä»Šå›è¿½åŠ ã•ã‚ŒãŸãƒªã‚½ãƒ¼ã‚¹ã®ãƒãƒ³ãƒ‰ãƒ«
 
 	pHandle->HandleCPU = handleCPU;
 	pHandle->HandleGPU = handleGPU;
@@ -60,23 +60,23 @@ DescriptorHandle* DescriptorHeap::Register(Texture2D* texture)
 	auto device = g_Engine->Device();
 	auto resource = texture->Resource();
 	auto desc = texture->ViewDesc();
-	device->CreateShaderResourceView(resource, &desc, pHandle->HandleCPU); // ƒVƒF[ƒ_[ƒŠƒ\[ƒXƒrƒ…[ì¬
+	device->CreateShaderResourceView(resource, &desc, pHandle->HandleCPU); // ã‚·ã‚§ãƒ¼ãƒ€ãƒ¼ãƒªã‚½ãƒ¼ã‚¹ãƒ“ãƒ¥ãƒ¼ä½œæˆ
 
 	m_pHandles.push_back(pHandle);
-	return pHandle; // ƒnƒ“ƒhƒ‹‚ğ•Ô‚·
+	return pHandle; // ãƒãƒ³ãƒ‰ãƒ«ã‚’è¿”ã™
 }
 
 DescriptorHandle* DescriptorHeap::RegisterBuffer(
-	ID3D12Resource* resource,
-	UINT            numElements,
-	UINT            stride)
+        ID3D12Resource* resource,
+        UINT            numElements,
+        UINT            stride)
 {
 	auto count = m_pHandles.size();
 	if (HANDLE_MAX <= count) return nullptr;
 
 	auto pHandle = new DescriptorHandle();
 
-	// CPU/GPU —¼•û‚Ìƒnƒ“ƒhƒ‹‚ğæ“¾
+	// CPU/GPU ä¸¡æ–¹ã®ãƒãƒ³ãƒ‰ãƒ«ã‚’å–å¾—
 	auto cpu = m_pHeap->GetCPUDescriptorHandleForHeapStart();
 	cpu.ptr += m_IncrementSize * count;
 	auto gpu = m_pHeap->GetGPUDescriptorHandleForHeapStart();
@@ -85,7 +85,7 @@ DescriptorHandle* DescriptorHeap::RegisterBuffer(
 	pHandle->HandleCPU = cpu;
 	pHandle->HandleGPU = gpu;
 
-	// SRV ƒfƒXƒNƒŠƒvƒ^‚ğì¬
+	// SRV ãƒ‡ã‚¹ã‚¯ãƒªãƒ—ã‚¿ã‚’ä½œæˆ
 	D3D12_SHADER_RESOURCE_VIEW_DESC desc{};
 	desc.Format = DXGI_FORMAT_UNKNOWN;
 	desc.ViewDimension = D3D12_SRV_DIMENSION_BUFFER;
@@ -94,10 +94,42 @@ DescriptorHandle* DescriptorHeap::RegisterBuffer(
 	desc.Buffer.StructureByteStride = stride;
 	desc.Buffer.Flags = D3D12_BUFFER_SRV_FLAG_NONE;
 
-	// ÀÛ‚É GPU ‚Öƒrƒ…[‚ğ‘‚«‚Ş
+	// å®Ÿéš›ã« GPU ã¸ãƒ“ãƒ¥ãƒ¼ã‚’æ›¸ãè¾¼ã‚€
 	g_Engine->Device()->CreateShaderResourceView(
 		resource, &desc, cpu);
 
-	m_pHandles.push_back(pHandle);
-	return pHandle;
+        m_pHandles.push_back(pHandle);
+        return pHandle;
+}
+
+DescriptorHandle* DescriptorHeap::RegisterBufferUAV(
+        ID3D12Resource* resource,
+        UINT            numElements,
+        UINT            stride)
+{
+        auto count = m_pHandles.size();
+        if (HANDLE_MAX <= count) return nullptr;
+
+        auto pHandle = new DescriptorHandle();
+
+        auto cpu = m_pHeap->GetCPUDescriptorHandleForHeapStart();
+        cpu.ptr += m_IncrementSize * count;
+        auto gpu = m_pHeap->GetGPUDescriptorHandleForHeapStart();
+        gpu.ptr += m_IncrementSize * count;
+
+        pHandle->HandleCPU = cpu;
+        pHandle->HandleGPU = gpu;
+
+        D3D12_UNORDERED_ACCESS_VIEW_DESC desc{};
+        desc.Format = DXGI_FORMAT_UNKNOWN;
+        desc.ViewDimension = D3D12_UAV_DIMENSION_BUFFER;
+        desc.Buffer.NumElements = numElements;
+        desc.Buffer.StructureByteStride = stride;
+        desc.Buffer.Flags = D3D12_BUFFER_UAV_FLAG_NONE;
+
+        g_Engine->Device()->CreateUnorderedAccessView(
+                resource, nullptr, &desc, cpu);
+
+        m_pHandles.push_back(pHandle);
+        return pHandle;
 }

--- a/DirectX12/DescriptorHeap.h
+++ b/DirectX12/DescriptorHeap.h
@@ -16,19 +16,25 @@ public:
 class DescriptorHeap
 {
 public:
-	DescriptorHeap(); // ƒRƒ“ƒXƒgƒ‰ƒNƒ^‚Å¶¬‚·‚é
-	ID3D12DescriptorHeap* GetHeap(); // ƒfƒBƒXƒNƒŠƒvƒ^ƒq[ƒv‚ğ•Ô‚·
-	DescriptorHandle* Register(Texture2D* texture); // ƒeƒNƒXƒ`ƒƒ[‚ğƒfƒBƒXƒNƒŠƒvƒ^ƒq[ƒv‚É“o˜^‚µAƒnƒ“ƒhƒ‹‚ğ•Ô‚·
-	DescriptorHandle* RegisterBuffer(
-		ID3D12Resource* resource,
-		UINT            numElements,
-		UINT            stride
-	);
+	DescriptorHeap(); // ã‚³ãƒ³ã‚¹ãƒˆãƒ©ã‚¯ã‚¿ã§ç”Ÿæˆã™ã‚‹
+	ID3D12DescriptorHeap* GetHeap(); // ãƒ‡ã‚£ã‚¹ã‚¯ãƒªãƒ—ã‚¿ãƒ’ãƒ¼ãƒ—ã‚’è¿”ã™
+	DescriptorHandle* Register(Texture2D* texture); // ãƒ†ã‚¯ã‚¹ãƒãƒ£ãƒ¼ã‚’ãƒ‡ã‚£ã‚¹ã‚¯ãƒªãƒ—ã‚¿ãƒ’ãƒ¼ãƒ—ã«ç™»éŒ²ã—ã€ãƒãƒ³ãƒ‰ãƒ«ã‚’è¿”ã™
+    DescriptorHandle* RegisterBuffer(
+            ID3D12Resource* resource,
+            UINT            numElements,
+            UINT            stride
+    );
+
+    DescriptorHandle* RegisterBufferUAV(
+            ID3D12Resource* resource,
+            UINT            numElements,
+            UINT            stride
+    );
 
 private:
-	bool m_IsValid = false; // ¶¬‚É¬Œ÷‚µ‚½‚©‚Ç‚¤‚©
+	bool m_IsValid = false; // ç”Ÿæˆã«æˆåŠŸã—ãŸã‹ã©ã†ã‹
 	UINT m_IncrementSize = 0;
-	ComPtr<ID3D12DescriptorHeap> m_pHeap = nullptr; // ƒfƒBƒXƒNƒŠƒvƒ^ƒq[ƒv–{‘Ì
-	std::vector<DescriptorHandle*> m_pHandles; // “o˜^‚³‚ê‚Ä‚¢‚éƒnƒ“ƒhƒ‹
+	ComPtr<ID3D12DescriptorHeap> m_pHeap = nullptr; // ãƒ‡ã‚£ã‚¹ã‚¯ãƒªãƒ—ã‚¿ãƒ’ãƒ¼ãƒ—æœ¬ä½“
+	std::vector<DescriptorHandle*> m_pHandles; // ç™»éŒ²ã•ã‚Œã¦ã„ã‚‹ãƒãƒ³ãƒ‰ãƒ«
 
 };

--- a/DirectX12/FluidSystem.cpp
+++ b/DirectX12/FluidSystem.cpp
@@ -2,144 +2,371 @@
 #include "Engine.h"
 #include "MetaBallPipelineState.h"
 #include "RandomUtil.h"
+#include "ComputePipelineState.h"
 #include <d3dx12.h>
+#include <cstdio>
 #include <algorithm>
 #include <cmath>
+#include <random>
 
 using namespace DirectX;
 
 namespace
 {
-    // PBFで使用するカーネル関数（Poly6）
+    // GPUバッファ用の粒子構造体
+    struct GPUFluidParticle
+    {
+        XMFLOAT3 position;
+        float    pad0 = 0.0f;
+        XMFLOAT3 velocity;
+        float    pad1 = 0.0f;
+    };
+
+    struct ParticleMetaGPU
+    {
+        XMFLOAT3 position;
+        float    radius;
+    };
+
+    // PBFカーネル関数（Poly6）
     float Poly6(float r, float h)
     {
         if (r >= h)
         {
             return 0.0f;
         }
-        const float diff = h * h - r * r;
-        const float coeff = 315.0f / (64.0f * XM_PI * std::pow(h, 9));
+        float diff = h * h - r * r;
+        float coeff = 315.0f / (64.0f * XM_PI * std::pow(h, 9));
         return coeff * diff * diff * diff;
     }
 
-    // PBFで使用するカーネル勾配（Spiky）
+    // PBFカーネルの勾配（Spiky）
     XMFLOAT3 GradSpiky(const XMFLOAT3& rij, float r, float h)
     {
         if (r <= 1e-6f || r >= h)
         {
             return XMFLOAT3(0.0f, 0.0f, 0.0f);
         }
-        const float coeff = -45.0f / (XM_PI * std::pow(h, 6));
-        const float scale = coeff * (h - r) * (h - r) / r;
+        float coeff = -45.0f / (XM_PI * std::pow(h, 6));
+        float scale = coeff * (h - r) * (h - r) / r;
         return XMFLOAT3(rij.x * scale, rij.y * scale, rij.z * scale);
     }
 
-    XMFLOAT3 Add(const XMFLOAT3& a, const XMFLOAT3& b)
+    inline float Length(const XMFLOAT3& v)
     {
-        return XMFLOAT3(a.x + b.x, a.y + b.y, a.z + b.z);
+        return std::sqrt(v.x * v.x + v.y * v.y + v.z * v.z);
     }
+}
 
-    XMFLOAT3 Sub(const XMFLOAT3& a, const XMFLOAT3& b)
+FluidMaterial CreateFluidMaterial(FluidMaterialPreset preset)
+{
+    FluidMaterial material{};
+    switch (preset)
     {
-        return XMFLOAT3(a.x - b.x, a.y - b.y, a.z - b.z);
+    case FluidMaterialPreset::Magma:
+        material.restDensity = 1500.0f;
+        material.particleMass = 1.2f;
+        material.smoothingRadius = 0.14f;
+        material.viscosity = 0.25f;      // 高い粘性でゆっくり流れる
+        material.stiffness = 350.0f;
+        material.renderRadius = 0.12f;
+        material.lambdaEpsilon = 150.0f;
+        material.xsphC = 0.15f;
+        material.solverIterations = 6;
+        break;
+    case FluidMaterialPreset::Water:
+    default:
+        material = FluidMaterial();
+        break;
     }
+    return material;
+}
 
-    XMFLOAT3 Mul(const XMFLOAT3& v, float s)
-    {
-        return XMFLOAT3(v.x * s, v.y * s, v.z * s);
-    }
-
-    float Dot(const XMFLOAT3& a, const XMFLOAT3& b)
-    {
-        return a.x * b.x + a.y * b.y + a.z * b.z;
-    }
-
-    float Length(const XMFLOAT3& v)
-    {
-        return std::sqrt(Dot(v, v));
-    }
-
-    // GPUへ渡す粒子メタデータ構造体
-    struct ParticleMetaGPU
-    {
-        XMFLOAT3 position; // ワールド座標
-        float radius;      // レイマーチ半径
-    };
+FluidSystem::FluidSystem()
+    : m_spatialGrid(0.12f)
+{
+    m_material = CreateFluidMaterial(FluidMaterialPreset::Water);
+    m_boundsMin = XMFLOAT3(-2.0f, 0.0f, -2.0f);
+    m_boundsMax = XMFLOAT3(2.0f, 4.0f, 2.0f);
+    m_gridDim = XMUINT3(1, 1, 1);
 }
 
 void FluidSystem::Init(ID3D12Device* device, DXGI_FORMAT rtvFormat, UINT maxParticles, UINT threadGroupCount)
 {
-    (void)device;
-    (void)rtvFormat;
     (void)threadGroupCount;
-    // GPU版は未実装なのでCPUで扱える粒子数に制限する
-    m_maxParticles = std::min<UINT>(maxParticles, 512);
+    m_device = device;
+    m_rtvFormat = rtvFormat;
+    m_maxParticles = std::max<UINT>(1u, maxParticles);
+    m_cpuParticles.clear();
+    m_cpuParticles.reserve(m_maxParticles);
+    m_particleCount = 0;
 
-    m_cpuParticles.resize(m_maxParticles);
-    m_particleCount = m_maxParticles;
+    UpdateGridSettings();
+    CreateMetaPipeline(device, rtvFormat);
+    CreateGPUResources(device);
 
-    // 粒子初期配置（簡易的に立方体内へランダム配置）
-    for (UINT i = 0; i < m_maxParticles; ++i)
-    {
-        FluidParticle& p = m_cpuParticles[i];
-        p.position = XMFLOAT3(RandFloat(-0.5f, 0.5f), RandFloat(0.0f, 1.0f), RandFloat(-0.5f, 0.5f));
-        p.velocity = XMFLOAT3(0.0f, 0.0f, 0.0f);
-        p.x_pred = p.position;
-        p.lambda = 0.0f;
-        p.density = m_restDensity;
-    }
+    // ひとまず初期状態として軽く粒子を生成しておく
+    SpawnParticlesSphere(XMFLOAT3(0.0f, 1.0f, 0.0f), 0.6f, m_maxParticles / 2);
 
-    // 粒子メタデータを格納するアップロードバッファを生成
-    const UINT64 bufferSize = sizeof(ParticleMetaGPU) * m_maxParticles;
-    auto heapProps = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
-    auto bufferDesc = CD3DX12_RESOURCE_DESC::Buffer(bufferSize);
-    if (FAILED(device->CreateCommittedResource(&heapProps, D3D12_HEAP_FLAG_NONE,
-            &bufferDesc, D3D12_RESOURCE_STATE_GENERIC_READ, nullptr,
-            IID_PPV_ARGS(m_particleMetaBuffer.ReleaseAndGetAddressOf()))))
-    {
-        printf("FluidSystem: 粒子メタデータ用バッファ生成に失敗しました\n");
-        return;
-    }
-
-    // SRVをディスクリプタヒープへ登録（シェーダーから粒子配列を参照するため）
-    m_particleSRV = g_Engine->CbvSrvUavHeap()->RegisterBuffer(
-        m_particleMetaBuffer.Get(), m_maxParticles, sizeof(ParticleMetaGPU));
-    if (!m_particleSRV)
-    {
-        printf("FluidSystem: 粒子SRVの登録に失敗しました\n");
-        return;
-    }
-
-    // メタボール描画用のルートシグネチャとPSOを生成
-    graphics::MetaBallPipeline::CreateRootSignature(device, m_metaRootSignature);
-    if (!m_metaRootSignature)
-    {
-        printf("FluidSystem: MetaBall用RootSignature生成に失敗しました\n");
-        return;
-    }
-
-    graphics::MetaBallPipeline::CreatePipelineState(device, m_metaRootSignature.Get(), rtvFormat, m_metaPipelineState);
-    if (!m_metaPipelineState)
-    {
-        printf("FluidSystem: MetaBall用PSO生成に失敗しました\n");
-        return;
-    }
-
-    // メタボール描画に必要な定数バッファ（ダブルバッファリング）
-    for (UINT i = 0; i < kFrameCount; ++i)
-    {
-        m_metaCB[i] = std::make_unique<ConstantBuffer>(sizeof(MetaConstants));
-        if (!m_metaCB[i] || !m_metaCB[i]->IsValid())
-        {
-            printf("FluidSystem: MetaBall定数バッファ生成に失敗しました\n");
-            return;
-        }
-    }
-
-    // 初期データをGPUバッファへコピー
     UpdateParticleBuffer();
 
     m_initialized = true;
+}
+
+void FluidSystem::UseGPU(bool enable)
+{
+    if (!m_initialized)
+    {
+        return;
+    }
+
+    if (enable && !m_gpuAvailable)
+    {
+        CreateGPUResources(m_device);
+    }
+
+    m_useGPU = enable && m_gpuAvailable;
+}
+
+FluidSimulationMode FluidSystem::Mode() const
+{
+    return (m_useGPU && m_gpuAvailable) ? FluidSimulationMode::GPU : FluidSimulationMode::CPU;
+}
+
+void FluidSystem::SetMaterialPreset(FluidMaterialPreset preset)
+{
+    SetMaterial(CreateFluidMaterial(preset));
+}
+
+void FluidSystem::SetMaterial(const FluidMaterial& material)
+{
+    m_material = material;
+    m_spatialGrid.SetCellSize(m_material.smoothingRadius);
+    UpdateGridSettings();
+
+    m_particleCount = static_cast<UINT>(std::min<size_t>(m_cpuParticles.size(), m_maxParticles));
+
+    m_cpuDirty = true;
+    m_gpuDirty = true;
+
+    // マテリアル変更時はGPUリソースも再作成して整合を取る
+    if (m_device)
+    {
+        CreateGPUResources(m_device);
+    }
+}
+
+void FluidSystem::SpawnParticlesSphere(const XMFLOAT3& center, float radius, UINT count)
+{
+    if (!m_initialized || count == 0)
+    {
+        return;
+    }
+
+    std::mt19937 rng{ std::random_device{}() };
+    std::uniform_real_distribution<float> dist(0.0f, 1.0f);
+
+    for (UINT i = 0; i < count && m_particleCount < m_maxParticles; ++i)
+    {
+        float u = dist(rng);
+        float v = dist(rng);
+        float theta = 2.0f * XM_PI * u;
+        float phi = std::acos(2.0f * v - 1.0f);
+        float r = radius * std::cbrt(dist(rng));
+
+        XMFLOAT3 offset{
+            r * std::sin(phi) * std::cos(theta),
+            r * std::cos(phi),
+            r * std::sin(phi) * std::sin(theta)
+        };
+
+        FluidParticle particle{};
+        particle.position = XMFLOAT3(center.x + offset.x, center.y + offset.y, center.z + offset.z);
+        particle.velocity = XMFLOAT3(0.0f, 0.0f, 0.0f);
+        particle.predicted = particle.position;
+        particle.density = m_material.restDensity;
+        particle.lambda = 0.0f;
+
+        m_cpuParticles.push_back(particle);
+        ++m_particleCount;
+    }
+
+    m_cpuDirty = true;
+    m_gpuDirty = true;
+}
+
+void FluidSystem::RemoveParticlesSphere(const XMFLOAT3& center, float radius)
+{
+    if (!m_initialized || m_particleCount == 0)
+    {
+        return;
+    }
+
+    float r2 = radius * radius;
+    auto it = std::remove_if(m_cpuParticles.begin(), m_cpuParticles.end(), [&](const FluidParticle& p)
+        {
+            XMFLOAT3 diff{ p.position.x - center.x, p.position.y - center.y, p.position.z - center.z };
+            float len2 = diff.x * diff.x + diff.y * diff.y + diff.z * diff.z;
+            return len2 <= r2;
+        });
+    m_cpuParticles.erase(it, m_cpuParticles.end());
+    m_particleCount = static_cast<UINT>(std::min<size_t>(m_cpuParticles.size(), m_maxParticles));
+
+    m_cpuDirty = true;
+    m_gpuDirty = true;
+}
+
+void FluidSystem::QueueGather(const XMFLOAT3& target, float radius, float strength)
+{
+    m_gatherOps.push_back({ target, radius, strength });
+}
+
+void FluidSystem::QueueSplash(const XMFLOAT3& position, float radius, float impulse)
+{
+    m_splashOps.push_back({ position, radius, impulse });
+}
+
+void FluidSystem::ClearDynamicOperations()
+{
+    m_gatherOps.clear();
+    m_splashOps.clear();
+}
+
+float FluidSystem::EffectiveTimeStep(float dt) const
+{
+    const float minStep = 1.0f / 240.0f;
+    const float maxStep = 1.0f / 30.0f;
+    return std::clamp(dt, minStep, maxStep);
+}
+
+void FluidSystem::Simulate(ID3D12GraphicsCommandList* cmd, float dt)
+{
+    if (!m_initialized)
+    {
+        return;
+    }
+
+    m_particleCount = static_cast<UINT>(std::min<size_t>(m_cpuParticles.size(), m_maxParticles));
+    if (m_particleCount == 0)
+    {
+        return;
+    }
+
+    float step = EffectiveTimeStep(dt);
+
+    if (Mode() == FluidSimulationMode::GPU)
+    {
+        // 前フレームの結果を読み戻してCPU側と同期
+        if (m_pendingReadback)
+        {
+            ReadbackGPUToCPU();
+        }
+
+        ApplyExternalOperationsCPU(step);
+        UploadCPUToGPU(cmd);
+        UpdateComputeParams(step);
+        StepGPU(cmd, step);
+        m_activeMetaSRV = m_gpuMetaSRV;
+    }
+    else
+    {
+        ApplyExternalOperationsCPU(step);
+        StepCPU(step);
+        UpdateParticleBuffer();
+        m_activeMetaSRV = m_cpuMetaSRV;
+    }
+}
+
+void FluidSystem::Render(ID3D12GraphicsCommandList* cmd,
+    const XMFLOAT4X4& invViewProj,
+    const XMFLOAT3& camPos,
+    float isoLevel)
+{
+    if (!m_initialized || !cmd || m_particleCount == 0 || !m_activeMetaSRV)
+    {
+        return;
+    }
+
+    UINT frameIndex = g_Engine->CurrentBackBufferIndex();
+    MetaConstants* cb = m_metaCB[frameIndex]->GetPtr<MetaConstants>();
+
+    XMMATRIX invVP = XMLoadFloat4x4(&invViewProj);
+    invVP = XMMatrixTranspose(invVP);
+    XMStoreFloat4x4(&cb->InvViewProj, invVP);
+
+    cb->CamRadius = XMFLOAT4(camPos.x, camPos.y, camPos.z, m_material.renderRadius);
+    cb->IsoCount = XMFLOAT4(isoLevel * 0.6f, static_cast<float>(m_particleCount), m_rayStepScale, 0.0f);
+
+    ID3D12DescriptorHeap* heaps[] = { g_Engine->CbvSrvUavHeap()->GetHeap() };
+    cmd->SetDescriptorHeaps(1, heaps);
+    cmd->SetGraphicsRootSignature(m_metaRootSignature.Get());
+    cmd->SetPipelineState(m_metaPipelineState.Get());
+    cmd->SetGraphicsRootDescriptorTable(0, m_activeMetaSRV->HandleGPU);
+    cmd->SetGraphicsRootConstantBufferView(1, m_metaCB[frameIndex]->GetAddress());
+    cmd->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+    cmd->DrawInstanced(3, 1, 0, 0);
+}
+
+void FluidSystem::ApplyExternalOperationsCPU(float dt)
+{
+    if (m_cpuParticles.empty())
+    {
+        return;
+    }
+
+    bool modified = false;
+
+    // 集束処理
+    for (const auto& op : m_gatherOps)
+    {
+        XMVECTOR target = XMLoadFloat3(&op.target);
+        for (auto& particle : m_cpuParticles)
+        {
+            XMVECTOR pos = XMLoadFloat3(&particle.position);
+            XMVECTOR diff = XMVectorSubtract(target, pos);
+            float dist = XMVectorGetX(XMVector3Length(diff));
+            if (dist < op.radius && dist > 1e-5f)
+            {
+                float weight = 1.0f - (dist / op.radius);
+                float accel = op.strength * weight;
+                XMVECTOR dir = XMVector3Normalize(diff);
+                XMVECTOR vel = XMLoadFloat3(&particle.velocity);
+                vel = XMVectorAdd(vel, XMVectorScale(dir, accel * dt));
+                XMStoreFloat3(&particle.velocity, vel);
+                modified = true;
+            }
+        }
+    }
+
+    // 発散処理は1回で取り除く
+    if (!m_splashOps.empty())
+    {
+        for (const auto& op : m_splashOps)
+        {
+            XMVECTOR origin = XMLoadFloat3(&op.origin);
+            for (auto& particle : m_cpuParticles)
+            {
+                XMVECTOR pos = XMLoadFloat3(&particle.position);
+                XMVECTOR diff = XMVectorSubtract(pos, origin);
+                float dist = XMVectorGetX(XMVector3Length(diff));
+                if (dist < op.radius && dist > 1e-5f)
+                {
+                    float weight = 1.0f - (dist / op.radius);
+                    XMVECTOR dir = XMVector3Normalize(diff);
+                    XMVECTOR vel = XMLoadFloat3(&particle.velocity);
+                    vel = XMVectorAdd(vel, XMVectorScale(dir, op.impulse * weight));
+                    XMStoreFloat3(&particle.velocity, vel);
+                    modified = true;
+                }
+            }
+        }
+        m_splashOps.clear();
+    }
+
+    if (modified)
+    {
+        m_cpuDirty = true;
+    }
 }
 
 void FluidSystem::StepCPU(float dt)
@@ -149,193 +376,660 @@ void FluidSystem::StepCPU(float dt)
         return;
     }
 
-    const float h = m_smoothingRadius;
-    const float mass = m_particleMass;
-    const float restDensity = m_restDensity;
-    const float epsilon = m_epsilon;
+    const float h = m_material.smoothingRadius;
+    const float mass = m_material.particleMass;
+    const float restDensity = m_material.restDensity;
+    const float epsilon = m_material.lambdaEpsilon;
     const float sCorrK = -0.001f;
     const float sCorrN = 4.0f;
     const float deltaQ = 0.3f * h;
     const float invRestDensity = 1.0f / restDensity;
+    const XMFLOAT3 gravity = XMFLOAT3(0.0f, -9.8f, 0.0f);
 
-    // 1. 外力適用と予測位置更新
-    for (auto& p : m_cpuParticles)
+    m_spatialGrid.Clear();
+
+    // 外力適用と予測位置計算
+    for (size_t i = 0; i < m_cpuParticles.size(); ++i)
     {
-        p.velocity = Add(p.velocity, Mul(m_gravity, dt));
-        p.x_pred = Add(p.position, Mul(p.velocity, dt));
-        p.lambda = 0.0f;
+        auto& particle = m_cpuParticles[i];
+        XMVECTOR vel = XMLoadFloat3(&particle.velocity);
+        XMVECTOR grav = XMLoadFloat3(&gravity);
+        vel = XMVectorAdd(vel, XMVectorScale(grav, dt));
+        XMStoreFloat3(&particle.velocity, vel);
+
+        XMVECTOR pos = XMLoadFloat3(&particle.position);
+        XMVECTOR pred = XMVectorAdd(pos, XMVectorScale(vel, dt));
+        XMStoreFloat3(&particle.predicted, pred);
+        particle.lambda = 0.0f;
+
+        m_spatialGrid.Insert(i, particle.predicted);
     }
 
-    // 2. コンストレイントソルバ
-    for (int iter = 0; iter < m_solverIterations; ++iter)
+    std::vector<size_t> neighbors;
+    neighbors.reserve(64);
+    std::vector<size_t> xsphNeighbors;
+    xsphNeighbors.reserve(64);
+
+    for (int iteration = 0; iteration < m_material.solverIterations; ++iteration)
     {
-        // 密度とλの計算
+        // λ計算
         for (size_t i = 0; i < m_cpuParticles.size(); ++i)
         {
-            auto& pi = m_cpuParticles[i];
+            FluidParticle& pi = m_cpuParticles[i];
+            neighbors.clear();
+            m_spatialGrid.Query(pi.predicted, h, neighbors);
+
             float density = 0.0f;
-            for (size_t j = 0; j < m_cpuParticles.size(); ++j)
+            for (size_t idx : neighbors)
             {
-                const auto& pj = m_cpuParticles[j];
-                const XMFLOAT3 rij = Sub(pi.x_pred, pj.x_pred);
-                const float r = Length(rij);
+                const FluidParticle& pj = m_cpuParticles[idx];
+                XMFLOAT3 rij{ pi.predicted.x - pj.predicted.x, pi.predicted.y - pj.predicted.y, pi.predicted.z - pj.predicted.z };
+                float r = Length(rij);
                 density += mass * Poly6(r, h);
             }
-            pi.density = (std::max)(density, restDensity * 0.1f);
-            const float Ci = pi.density * invRestDensity - 1.0f;
+            pi.density = std::max(density, restDensity * 0.1f);
+            float Ci = pi.density * invRestDensity - 1.0f;
 
-            XMFLOAT3 gradSum = XMFLOAT3(0.0f, 0.0f, 0.0f);
+            XMFLOAT3 gradSum{ 0.0f, 0.0f, 0.0f };
             float sumGrad2 = 0.0f;
-            for (size_t j = 0; j < m_cpuParticles.size(); ++j)
+
+            for (size_t idx : neighbors)
             {
-                if (i == j)
+                if (idx == i)
                 {
                     continue;
                 }
-                const auto& pj = m_cpuParticles[j];
-                const XMFLOAT3 rij = Sub(pi.x_pred, pj.x_pred);
-                const float r = Length(rij);
+                const FluidParticle& pj = m_cpuParticles[idx];
+                XMFLOAT3 rij{ pi.predicted.x - pj.predicted.x, pi.predicted.y - pj.predicted.y, pi.predicted.z - pj.predicted.z };
+                float r = Length(rij);
                 XMFLOAT3 grad = GradSpiky(rij, r, h);
-                grad = Mul(grad, mass * invRestDensity);
-                gradSum = Add(gradSum, grad);
-                sumGrad2 += Dot(grad, grad);
+                grad.x *= mass * invRestDensity;
+                grad.y *= mass * invRestDensity;
+                grad.z *= mass * invRestDensity;
+                gradSum.x += grad.x;
+                gradSum.y += grad.y;
+                gradSum.z += grad.z;
+                sumGrad2 += grad.x * grad.x + grad.y * grad.y + grad.z * grad.z;
             }
-            sumGrad2 += Dot(gradSum, gradSum);
 
-            pi.lambda = Ci / (sumGrad2 + epsilon);
+            sumGrad2 += gradSum.x * gradSum.x + gradSum.y * gradSum.y + gradSum.z * gradSum.z;
+            pi.lambda = -Ci / (sumGrad2 + epsilon);
         }
 
-        // Δpの計算
+        // Δp計算
         for (size_t i = 0; i < m_cpuParticles.size(); ++i)
         {
-            auto& pi = m_cpuParticles[i];
-            XMFLOAT3 delta = XMFLOAT3(0.0f, 0.0f, 0.0f);
-            for (size_t j = 0; j < m_cpuParticles.size(); ++j)
+            FluidParticle& pi = m_cpuParticles[i];
+            neighbors.clear();
+            m_spatialGrid.Query(pi.predicted, h, neighbors);
+
+            XMFLOAT3 delta{ 0.0f, 0.0f, 0.0f };
+            for (size_t idx : neighbors)
             {
-                if (i == j)
+                if (idx == i)
                 {
                     continue;
                 }
-                const auto& pj = m_cpuParticles[j];
-                const XMFLOAT3 rij = Sub(pi.x_pred, pj.x_pred);
-                const float r = Length(rij);
+                const FluidParticle& pj = m_cpuParticles[idx];
+                XMFLOAT3 rij{ pi.predicted.x - pj.predicted.x, pi.predicted.y - pj.predicted.y, pi.predicted.z - pj.predicted.z };
+                float r = Length(rij);
                 if (r >= h)
                 {
                     continue;
                 }
-                const float w = Poly6(r, h);
+                float w = Poly6(r, h);
                 float corr = 0.0f;
-                const float wq = Poly6(deltaQ, h);
+                float wq = Poly6(deltaQ, h);
                 if (wq > 0.0f)
                 {
                     corr = sCorrK * std::pow(w / wq, sCorrN);
                 }
                 XMFLOAT3 grad = GradSpiky(rij, r, h);
-                const float factor = (pi.lambda + pj.lambda + corr) * mass * invRestDensity;
-                delta = Add(delta, Mul(grad, factor));
-            }
-            pi.x_pred = Add(pi.x_pred, delta);
-
-            // 床（y=0）との衝突処理。沈み込み防止のため軽く押し戻す
-            if (pi.x_pred.y < 0.0f)
-            {
-                pi.x_pred.y = 0.0f;
+                float factor = (pi.lambda + pj.lambda + corr) * mass * invRestDensity;
+                delta.x += grad.x * factor;
+                delta.y += grad.y * factor;
+                delta.z += grad.z * factor;
             }
 
-            // 簡易的な境界（立方体）
-            pi.x_pred.x = std::clamp(pi.x_pred.x, -1.0f, 1.0f);
-            pi.x_pred.y = std::clamp(pi.x_pred.y, 0.0f, 2.0f);
-            pi.x_pred.z = std::clamp(pi.x_pred.z, -1.0f, 1.0f);
+            pi.predicted.x += delta.x;
+            pi.predicted.y += delta.y;
+            pi.predicted.z += delta.z;
+
+            ResolveBounds(pi);
         }
     }
 
-    // 3. 速度と位置の更新
-    for (auto& p : m_cpuParticles)
+    // 速度と位置の更新（XSPHによる安定化込み）
+    for (auto& particle : m_cpuParticles)
     {
-        const XMFLOAT3 delta = Sub(p.x_pred, p.position);
-        p.velocity = Mul(delta, 1.0f / dt);
-        p.position = p.x_pred;
+        XMFLOAT3 delta{ particle.predicted.x - particle.position.x,
+            particle.predicted.y - particle.position.y,
+            particle.predicted.z - particle.position.z };
+        particle.velocity = XMFLOAT3(delta.x / dt, delta.y / dt, delta.z / dt);
+
+        // XSPH粘性
+        xsphNeighbors.clear();
+        m_spatialGrid.Query(particle.predicted, h, xsphNeighbors);
+        XMFLOAT3 xsph{ 0.0f, 0.0f, 0.0f };
+        for (size_t idx : xsphNeighbors)
+        {
+            if (&particle == &m_cpuParticles[idx])
+            {
+                continue;
+            }
+            const FluidParticle& pj = m_cpuParticles[idx];
+            XMFLOAT3 vij{ pj.velocity.x - particle.velocity.x,
+                pj.velocity.y - particle.velocity.y,
+                pj.velocity.z - particle.velocity.z };
+            XMFLOAT3 rij{ particle.predicted.x - pj.predicted.x,
+                particle.predicted.y - pj.predicted.y,
+                particle.predicted.z - pj.predicted.z };
+            float r = Length(rij);
+            xsph.x += Poly6(r, h) * vij.x;
+            xsph.y += Poly6(r, h) * vij.y;
+            xsph.z += Poly6(r, h) * vij.z;
+        }
+        particle.velocity.x += m_material.xsphC * xsph.x;
+        particle.velocity.y += m_material.xsphC * xsph.y;
+        particle.velocity.z += m_material.xsphC * xsph.z;
+
+        particle.position = particle.predicted;
     }
+
+    m_cpuDirty = true;
+}
+
+void FluidSystem::ResolveBounds(FluidParticle& p) const
+{
+    p.predicted.x = std::clamp(p.predicted.x, m_boundsMin.x, m_boundsMax.x);
+    p.predicted.y = std::clamp(p.predicted.y, m_boundsMin.y, m_boundsMax.y);
+    p.predicted.z = std::clamp(p.predicted.z, m_boundsMin.z, m_boundsMax.z);
+}
+
+void FluidSystem::UploadCPUToGPU(ID3D12GraphicsCommandList* cmd)
+{
+    if (!m_gpuAvailable || !cmd || !m_gpuUpload)
+    {
+        return;
+    }
+
+    if (!m_cpuDirty && !m_gpuDirty)
+    {
+        return;
+    }
+
+    const UINT64 bufferSize = sizeof(GPUFluidParticle) * m_particleCount;
+    if (bufferSize == 0)
+    {
+        return;
+    }
+
+    GPUFluidParticle* mapped = nullptr;
+    if (SUCCEEDED(m_gpuUpload->Map(0, nullptr, reinterpret_cast<void**>(&mapped))) && mapped)
+    {
+        for (UINT i = 0; i < m_particleCount; ++i)
+        {
+            mapped[i].position = m_cpuParticles[i].position;
+            mapped[i].velocity = m_cpuParticles[i].velocity;
+        }
+        m_gpuUpload->Unmap(0, nullptr);
+    }
+
+    for (int i = 0; i < 2; ++i)
+    {
+        auto& buffer = m_gpuParticleBuffers[i];
+        if (!buffer.resource)
+        {
+            continue;
+        }
+        auto toCopy = CD3DX12_RESOURCE_BARRIER::Transition(buffer.resource.Get(), buffer.state, D3D12_RESOURCE_STATE_COPY_DEST);
+        cmd->ResourceBarrier(1, &toCopy);
+        buffer.state = D3D12_RESOURCE_STATE_COPY_DEST;
+        cmd->CopyBufferRegion(buffer.resource.Get(), 0, m_gpuUpload.Get(), 0, sizeof(GPUFluidParticle) * m_particleCount);
+        auto toSRV = CD3DX12_RESOURCE_BARRIER::Transition(buffer.resource.Get(), buffer.state, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+        cmd->ResourceBarrier(1, &toSRV);
+        buffer.state = D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
+    }
+
+    m_cpuDirty = false;
+    m_gpuDirty = false;
+}
+
+void FluidSystem::UpdateComputeParams(float dt)
+{
+    if (!m_computeParamsCB)
+    {
+        m_computeParamsCB = std::make_unique<ConstantBuffer>(sizeof(GPUParams));
+    }
+
+    GPUParams* params = m_computeParamsCB->GetPtr<GPUParams>();
+    params->restDensity = m_material.restDensity;
+    params->particleMass = m_material.particleMass;
+    params->viscosity = m_material.viscosity;
+    params->stiffness = m_material.stiffness;
+    params->radius = m_material.smoothingRadius;
+    params->timeStep = dt;
+    params->particleCount = m_particleCount;
+    params->pad0 = 0;
+    params->gridMin = m_boundsMin;
+    params->pad1 = 0.0f;
+    params->gridDim = m_gridDim;
+    params->pad2 = 0;
+
+    if (!m_dummyViewCB)
+    {
+        m_dummyViewCB = std::make_unique<ConstantBuffer>(sizeof(XMFLOAT4X4));
+        XMFLOAT4X4 identity;
+        XMStoreFloat4x4(&identity, XMMatrixIdentity());
+        *m_dummyViewCB->GetPtr<XMFLOAT4X4>() = identity;
+    }
+}
+
+void FluidSystem::StepGPU(ID3D12GraphicsCommandList* cmd, float dt)
+{
+    if (!m_gpuAvailable || !cmd || !m_buildGridPipeline || !m_particlePipeline)
+    {
+        return;
+    }
+
+    const UINT readIndex = m_gpuReadIndex;
+    const UINT writeIndex = 1 - m_gpuReadIndex;
+
+    auto& readBuffer = m_gpuParticleBuffers[readIndex];
+    auto& writeBuffer = m_gpuParticleBuffers[writeIndex];
+
+    auto toSRV = CD3DX12_RESOURCE_BARRIER::Transition(readBuffer.resource.Get(), readBuffer.state, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+    cmd->ResourceBarrier(1, &toSRV);
+    readBuffer.state = D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
+
+    auto toUAV = CD3DX12_RESOURCE_BARRIER::Transition(writeBuffer.resource.Get(), writeBuffer.state, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+    cmd->ResourceBarrier(1, &toUAV);
+    writeBuffer.state = D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
+
+    auto metaToUAV = CD3DX12_RESOURCE_BARRIER::Transition(m_gpuMetaBuffer.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+    cmd->ResourceBarrier(1, &metaToUAV);
+
+    auto gridCountToUAV = CD3DX12_RESOURCE_BARRIER::Transition(m_gpuGridCount.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+    cmd->ResourceBarrier(1, &gridCountToUAV);
+
+    auto gridTableToUAV = CD3DX12_RESOURCE_BARRIER::Transition(m_gpuGridTable.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+    cmd->ResourceBarrier(1, &gridTableToUAV);
+
+    ID3D12DescriptorHeap* heaps[] = { g_Engine->CbvSrvUavHeap()->GetHeap() };
+    cmd->SetDescriptorHeaps(1, heaps);
+    cmd->SetComputeRootSignature(m_computeRootSignature.Get());
+
+    // グリッド構築
+    cmd->SetPipelineState(m_buildGridPipeline->Get());
+    cmd->SetComputeRootConstantBufferView(0, m_computeParamsCB->GetAddress());
+    cmd->SetComputeRootConstantBufferView(1, m_dummyViewCB->GetAddress());
+    cmd->SetComputeRootDescriptorTable(2, readBuffer.srv->HandleGPU);
+    cmd->SetComputeRootDescriptorTable(3, writeBuffer.uav->HandleGPU);
+    cmd->SetComputeRootDescriptorTable(4, m_gpuMetaUAV->HandleGPU);
+    cmd->SetComputeRootDescriptorTable(5, m_gpuGridCountUAV->HandleGPU);
+    cmd->SetComputeRootDescriptorTable(6, m_gpuGridTableUAV->HandleGPU);
+
+    UINT cellCount = m_gridDim.x * m_gridDim.y * m_gridDim.z;
+    UINT totalThreads = std::max(m_particleCount, cellCount);
+    UINT groups = (totalThreads + 255) / 256;
+    cmd->Dispatch(groups, 1, 1);
+
+    // 粒子更新
+    cmd->SetPipelineState(m_particlePipeline->Get());
+    cmd->SetComputeRootConstantBufferView(0, m_computeParamsCB->GetAddress());
+    cmd->SetComputeRootConstantBufferView(1, m_dummyViewCB->GetAddress());
+    cmd->SetComputeRootDescriptorTable(2, readBuffer.srv->HandleGPU);
+    cmd->SetComputeRootDescriptorTable(3, writeBuffer.uav->HandleGPU);
+    cmd->SetComputeRootDescriptorTable(4, m_gpuMetaUAV->HandleGPU);
+    cmd->SetComputeRootDescriptorTable(5, m_gpuGridCountUAV->HandleGPU);
+    cmd->SetComputeRootDescriptorTable(6, m_gpuGridTableUAV->HandleGPU);
+
+    UINT groupsParticle = (m_particleCount + 255) / 256;
+    cmd->Dispatch(groupsParticle, 1, 1);
+
+    // 書き込み完了後の状態遷移
+    auto metaToSRV = CD3DX12_RESOURCE_BARRIER::Transition(m_gpuMetaBuffer.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+    cmd->ResourceBarrier(1, &metaToSRV);
+    auto gridCountToSRV = CD3DX12_RESOURCE_BARRIER::Transition(m_gpuGridCount.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+    cmd->ResourceBarrier(1, &gridCountToSRV);
+    auto gridTableToSRV = CD3DX12_RESOURCE_BARRIER::Transition(m_gpuGridTable.Get(), D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+    cmd->ResourceBarrier(1, &gridTableToSRV);
+
+    // 新しい結果を読み戻し用にコピー
+    auto toCopySrc = CD3DX12_RESOURCE_BARRIER::Transition(writeBuffer.resource.Get(), writeBuffer.state, D3D12_RESOURCE_STATE_COPY_SOURCE);
+    cmd->ResourceBarrier(1, &toCopySrc);
+    writeBuffer.state = D3D12_RESOURCE_STATE_COPY_SOURCE;
+    cmd->CopyBufferRegion(m_gpuReadback.Get(), 0, writeBuffer.resource.Get(), 0, sizeof(GPUFluidParticle) * m_particleCount);
+    auto backToSRV = CD3DX12_RESOURCE_BARRIER::Transition(writeBuffer.resource.Get(), writeBuffer.state, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+    cmd->ResourceBarrier(1, &backToSRV);
+    writeBuffer.state = D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
+
+    m_gpuReadIndex = writeIndex;
+    m_pendingReadback = true;
+}
+
+void FluidSystem::ReadbackGPUToCPU()
+{
+    if (!m_gpuReadback || !m_pendingReadback)
+    {
+        return;
+    }
+
+    GPUFluidParticle* mapped = nullptr;
+    if (SUCCEEDED(m_gpuReadback->Map(0, nullptr, reinterpret_cast<void**>(&mapped))) && mapped)
+    {
+        for (UINT i = 0; i < m_particleCount; ++i)
+        {
+            m_cpuParticles[i].position = mapped[i].position;
+            m_cpuParticles[i].velocity = mapped[i].velocity;
+            m_cpuParticles[i].predicted = mapped[i].position;
+        }
+        m_gpuReadback->Unmap(0, nullptr);
+    }
+
+    m_pendingReadback = false;
 }
 
 void FluidSystem::UpdateParticleBuffer()
 {
-    if (!m_particleMetaBuffer)
+    if (!m_cpuMetaBuffer)
     {
         return;
     }
-
-    const UINT cpuCount = static_cast<UINT>(m_cpuParticles.size());
-    const UINT count = (std::min)(cpuCount, m_maxParticles);
-    m_particleCount = count;
 
     ParticleMetaGPU* mapped = nullptr;
-    if (FAILED(m_particleMetaBuffer->Map(0, nullptr, reinterpret_cast<void**>(&mapped))) || !mapped)
+    if (FAILED(m_cpuMetaBuffer->Map(0, nullptr, reinterpret_cast<void**>(&mapped))) || !mapped)
     {
-        printf("FluidSystem : particle data map failed\n");
         return;
     }
 
-    // 使用している粒子をGPUバッファへ書き戻す
-    for (UINT i = 0; i < count; ++i)
+    for (UINT i = 0; i < m_particleCount; ++i)
     {
         mapped[i].position = m_cpuParticles[i].position;
-        mapped[i].radius = m_renderRadius;
+        mapped[i].radius = m_material.renderRadius;
     }
 
-    // 余剰領域は半径0で埋めて寄与を無効化しておく
-    for (UINT i = count; i < m_maxParticles; ++i)
+    for (UINT i = m_particleCount; i < m_maxParticles; ++i)
     {
         mapped[i].position = XMFLOAT3(0.0f, 0.0f, 0.0f);
         mapped[i].radius = 0.0f;
     }
 
-    m_particleMetaBuffer->Unmap(0, nullptr);
+    m_cpuMetaBuffer->Unmap(0, nullptr);
+    m_activeMetaSRV = m_cpuMetaSRV;
 }
 
-void FluidSystem::Simulate(ID3D12GraphicsCommandList*, float dt)
+void FluidSystem::CreateMetaPipeline(ID3D12Device* device, DXGI_FORMAT rtvFormat)
 {
-    if (!m_initialized)
+    graphics::MetaBallPipeline::CreateRootSignature(device, m_metaRootSignature);
+    graphics::MetaBallPipeline::CreatePipelineState(device, m_metaRootSignature.Get(), rtvFormat, m_metaPipelineState);
+
+    for (UINT i = 0; i < kFrameCount; ++i)
+    {
+        m_metaCB[i] = std::make_unique<ConstantBuffer>(sizeof(MetaConstants));
+    }
+
+    UINT64 bufferSize = sizeof(ParticleMetaGPU) * m_maxParticles;
+
+    // CPU更新用アップロードバッファ
+    auto cpuHeap = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
+    auto cpuDesc = CD3DX12_RESOURCE_DESC::Buffer(bufferSize);
+    if (FAILED(device->CreateCommittedResource(&cpuHeap, D3D12_HEAP_FLAG_NONE, &cpuDesc, D3D12_RESOURCE_STATE_GENERIC_READ, nullptr,
+        IID_PPV_ARGS(m_cpuMetaBuffer.ReleaseAndGetAddressOf()))))
+    {
+        printf("FluidSystem: CPUメタデータバッファ生成に失敗しました\n");
+        return;
+    }
+
+    m_cpuMetaSRV = g_Engine->CbvSrvUavHeap()->RegisterBuffer(m_cpuMetaBuffer.Get(), m_maxParticles, sizeof(ParticleMetaGPU));
+    m_activeMetaSRV = m_cpuMetaSRV;
+
+    // GPU書き込み用バッファ
+    auto gpuHeap = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
+    auto gpuDesc = CD3DX12_RESOURCE_DESC::Buffer(bufferSize, D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
+    if (FAILED(device->CreateCommittedResource(&gpuHeap, D3D12_HEAP_FLAG_NONE, &gpuDesc, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, nullptr,
+        IID_PPV_ARGS(m_gpuMetaBuffer.ReleaseAndGetAddressOf()))))
+    {
+        printf("FluidSystem: GPUメタデータバッファ生成に失敗しました\n");
+        return;
+    }
+
+    if (!m_gpuMetaSRV)
+    {
+        m_gpuMetaSRV = g_Engine->CbvSrvUavHeap()->RegisterBuffer(m_gpuMetaBuffer.Get(), m_maxParticles, sizeof(ParticleMetaGPU));
+    }
+    else
+    {
+        D3D12_SHADER_RESOURCE_VIEW_DESC desc{};
+        desc.Format = DXGI_FORMAT_UNKNOWN;
+        desc.ViewDimension = D3D12_SRV_DIMENSION_BUFFER;
+        desc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+        desc.Buffer.NumElements = m_maxParticles;
+        desc.Buffer.StructureByteStride = sizeof(ParticleMetaGPU);
+        g_Engine->Device()->CreateShaderResourceView(m_gpuMetaBuffer.Get(), &desc, m_gpuMetaSRV->HandleCPU);
+    }
+
+    if (!m_gpuMetaUAV)
+    {
+        m_gpuMetaUAV = g_Engine->CbvSrvUavHeap()->RegisterBufferUAV(m_gpuMetaBuffer.Get(), m_maxParticles, sizeof(ParticleMetaGPU));
+    }
+    else
+    {
+        D3D12_UNORDERED_ACCESS_VIEW_DESC desc{};
+        desc.Format = DXGI_FORMAT_UNKNOWN;
+        desc.ViewDimension = D3D12_UAV_DIMENSION_BUFFER;
+        desc.Buffer.NumElements = m_maxParticles;
+        desc.Buffer.StructureByteStride = sizeof(ParticleMetaGPU);
+        g_Engine->Device()->CreateUnorderedAccessView(m_gpuMetaBuffer.Get(), nullptr, &desc, m_gpuMetaUAV->HandleCPU);
+    }
+}
+
+void FluidSystem::CreateGPUResources(ID3D12Device* device)
+{
+    if (!device)
     {
         return;
     }
-    const float clampedDt = (std::max)(dt, 1.0f / 240.0f); // 極端に小さいdtを避ける
-    StepCPU(clampedDt);
-    UpdateParticleBuffer();
-}
 
-void FluidSystem::Render(ID3D12GraphicsCommandList* cmd,
-    const XMFLOAT4X4& invViewProj, const XMFLOAT3& camPos, float isoLevel)
-{
-    const UINT count = (std::min)(m_particleCount, m_maxParticles);
+    UpdateGridSettings();
 
-    if (!m_initialized || !cmd || count == 0 || !m_particleSRV)
+    UINT particleStride = sizeof(GPUFluidParticle);
+    UINT metaStride = sizeof(ParticleMetaGPU);
+    UINT particleBufferSize = particleStride * m_maxParticles;
+    UINT metaBufferSize = metaStride * m_maxParticles;
+    UINT cellCount = std::max<UINT>(1u, m_gridDim.x * m_gridDim.y * m_gridDim.z);
+
+    auto defaultHeap = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
+
+    for (int i = 0; i < 2; ++i)
     {
+        auto desc = CD3DX12_RESOURCE_DESC::Buffer(particleBufferSize, D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
+        HRESULT hr = device->CreateCommittedResource(&defaultHeap, D3D12_HEAP_FLAG_NONE, &desc, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, nullptr,
+            IID_PPV_ARGS(m_gpuParticleBuffers[i].resource.ReleaseAndGetAddressOf()));
+        if (FAILED(hr))
+        {
+            printf("FluidSystem: GPU粒子バッファ生成に失敗しました (%d)\n", i);
+            m_gpuAvailable = false;
+            return;
+        }
+        m_gpuParticleBuffers[i].state = D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
+
+        if (!m_gpuParticleBuffers[i].srv)
+        {
+            m_gpuParticleBuffers[i].srv = g_Engine->CbvSrvUavHeap()->RegisterBuffer(m_gpuParticleBuffers[i].resource.Get(), m_maxParticles, particleStride);
+        }
+        else
+        {
+            D3D12_SHADER_RESOURCE_VIEW_DESC descSrv{};
+            descSrv.Format = DXGI_FORMAT_UNKNOWN;
+            descSrv.ViewDimension = D3D12_SRV_DIMENSION_BUFFER;
+            descSrv.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+            descSrv.Buffer.NumElements = m_maxParticles;
+            descSrv.Buffer.StructureByteStride = particleStride;
+            g_Engine->Device()->CreateShaderResourceView(m_gpuParticleBuffers[i].resource.Get(), &descSrv, m_gpuParticleBuffers[i].srv->HandleCPU);
+        }
+
+        if (!m_gpuParticleBuffers[i].uav)
+        {
+            m_gpuParticleBuffers[i].uav = g_Engine->CbvSrvUavHeap()->RegisterBufferUAV(m_gpuParticleBuffers[i].resource.Get(), m_maxParticles, particleStride);
+        }
+        else
+        {
+            D3D12_UNORDERED_ACCESS_VIEW_DESC descUAV{};
+            descUAV.Format = DXGI_FORMAT_UNKNOWN;
+            descUAV.ViewDimension = D3D12_UAV_DIMENSION_BUFFER;
+            descUAV.Buffer.NumElements = m_maxParticles;
+            descUAV.Buffer.StructureByteStride = particleStride;
+            g_Engine->Device()->CreateUnorderedAccessView(m_gpuParticleBuffers[i].resource.Get(), nullptr, &descUAV, m_gpuParticleBuffers[i].uav->HandleCPU);
+        }
+    }
+
+    // グリッドバッファ
+    auto gridDesc = CD3DX12_RESOURCE_DESC::Buffer(sizeof(UINT) * cellCount, D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
+    HRESULT hrGrid = device->CreateCommittedResource(&defaultHeap, D3D12_HEAP_FLAG_NONE, &gridDesc, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, nullptr,
+        IID_PPV_ARGS(m_gpuGridCount.ReleaseAndGetAddressOf()));
+    if (FAILED(hrGrid))
+    {
+        printf("FluidSystem: グリッドカウントバッファ生成に失敗しました\n");
+        m_gpuAvailable = false;
+        return;
+    }
+    if (!m_gpuGridCountUAV)
+    {
+        m_gpuGridCountUAV = g_Engine->CbvSrvUavHeap()->RegisterBufferUAV(m_gpuGridCount.Get(), cellCount, sizeof(UINT));
+    }
+    else
+    {
+        D3D12_UNORDERED_ACCESS_VIEW_DESC desc{};
+        desc.Format = DXGI_FORMAT_UNKNOWN;
+        desc.ViewDimension = D3D12_UAV_DIMENSION_BUFFER;
+        desc.Buffer.NumElements = cellCount;
+        desc.Buffer.StructureByteStride = sizeof(UINT);
+        g_Engine->Device()->CreateUnorderedAccessView(m_gpuGridCount.Get(), nullptr, &desc, m_gpuGridCountUAV->HandleCPU);
+    }
+
+    auto tableDesc = CD3DX12_RESOURCE_DESC::Buffer(sizeof(UINT) * cellCount * 64, D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
+    HRESULT hrTable = device->CreateCommittedResource(&defaultHeap, D3D12_HEAP_FLAG_NONE, &tableDesc, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, nullptr,
+        IID_PPV_ARGS(m_gpuGridTable.ReleaseAndGetAddressOf()));
+    if (FAILED(hrTable))
+    {
+        printf("FluidSystem: グリッドテーブル生成に失敗しました\n");
+        m_gpuAvailable = false;
+        return;
+    }
+    if (!m_gpuGridTableUAV)
+    {
+        m_gpuGridTableUAV = g_Engine->CbvSrvUavHeap()->RegisterBufferUAV(m_gpuGridTable.Get(), cellCount * 64, sizeof(UINT));
+    }
+    else
+    {
+        D3D12_UNORDERED_ACCESS_VIEW_DESC desc{};
+        desc.Format = DXGI_FORMAT_UNKNOWN;
+        desc.ViewDimension = D3D12_UAV_DIMENSION_BUFFER;
+        desc.Buffer.NumElements = cellCount * 64;
+        desc.Buffer.StructureByteStride = sizeof(UINT);
+        g_Engine->Device()->CreateUnorderedAccessView(m_gpuGridTable.Get(), nullptr, &desc, m_gpuGridTableUAV->HandleCPU);
+    }
+
+    // アップロード・リードバック
+    auto uploadHeap = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
+    auto uploadDesc = CD3DX12_RESOURCE_DESC::Buffer(particleBufferSize);
+    HRESULT hrUpload = device->CreateCommittedResource(&uploadHeap, D3D12_HEAP_FLAG_NONE, &uploadDesc, D3D12_RESOURCE_STATE_GENERIC_READ, nullptr,
+        IID_PPV_ARGS(m_gpuUpload.ReleaseAndGetAddressOf()));
+    if (FAILED(hrUpload))
+    {
+        printf("FluidSystem: GPUアップロードバッファ生成に失敗しました\n");
+        m_gpuAvailable = false;
         return;
     }
 
-    const UINT frameIndex = g_Engine->CurrentBackBufferIndex();
-    auto* cb = m_metaCB[frameIndex]->GetPtr<MetaConstants>();
+    auto readbackHeap = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_READBACK);
+    auto readbackDesc = CD3DX12_RESOURCE_DESC::Buffer(particleBufferSize);
+    HRESULT hrReadback = device->CreateCommittedResource(&readbackHeap, D3D12_HEAP_FLAG_NONE, &readbackDesc, D3D12_RESOURCE_STATE_COPY_DEST, nullptr,
+        IID_PPV_ARGS(m_gpuReadback.ReleaseAndGetAddressOf()));
+    if (FAILED(hrReadback))
+    {
+        printf("FluidSystem: GPUリードバックバッファ生成に失敗しました\n");
+        m_gpuAvailable = false;
+        return;
+    }
 
-    // HLSL側は列優先行列を前提としているため、逆ビュー射影行列を転置してから書き込む
-    DirectX::XMMATRIX invVP = DirectX::XMLoadFloat4x4(&invViewProj);
-    invVP = DirectX::XMMatrixTranspose(invVP);
-    DirectX::XMStoreFloat4x4(&cb->InvViewProj, invVP);
+    // コンピュート用のルートシグネチャとPSO
+    CD3DX12_DESCRIPTOR_RANGE srvRange(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0);
+    CD3DX12_DESCRIPTOR_RANGE uavRange0(D3D12_DESCRIPTOR_RANGE_TYPE_UAV, 1, 0);
+    CD3DX12_DESCRIPTOR_RANGE uavRange1(D3D12_DESCRIPTOR_RANGE_TYPE_UAV, 1, 1);
+    CD3DX12_DESCRIPTOR_RANGE uavRange2(D3D12_DESCRIPTOR_RANGE_TYPE_UAV, 1, 2);
+    CD3DX12_DESCRIPTOR_RANGE uavRange3(D3D12_DESCRIPTOR_RANGE_TYPE_UAV, 1, 3);
 
-    cb->CamRadius = XMFLOAT4(camPos.x, camPos.y, camPos.z, m_renderRadius);
-    // ガウスカーネルの特性上しきい値は1未満で扱いやすいので少しスケールダウン
-    cb->IsoCount = XMFLOAT4(isoLevel * 0.6f, static_cast<float>(count), m_rayStepScale, 0.0f);
+    CD3DX12_ROOT_PARAMETER params[7];
+    params[0].InitAsConstantBufferView(0);
+    params[1].InitAsConstantBufferView(1);
+    params[2].InitAsDescriptorTable(1, &srvRange);
+    params[3].InitAsDescriptorTable(1, &uavRange0);
+    params[4].InitAsDescriptorTable(1, &uavRange1);
+    params[5].InitAsDescriptorTable(1, &uavRange2);
+    params[6].InitAsDescriptorTable(1, &uavRange3);
 
-    // SRVテーブルを参照できるようにディスクリプタヒープをセット
-    ID3D12DescriptorHeap* heaps[] = { g_Engine->CbvSrvUavHeap()->GetHeap() };
-    cmd->SetDescriptorHeaps(1, heaps);
+    CD3DX12_ROOT_SIGNATURE_DESC rootDesc;
+    rootDesc.Init(_countof(params), params, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_NONE);
 
-    cmd->SetGraphicsRootSignature(m_metaRootSignature.Get());
-    cmd->SetPipelineState(m_metaPipelineState.Get());
-    cmd->SetGraphicsRootDescriptorTable(0, m_particleSRV->HandleGPU);
-    cmd->SetGraphicsRootConstantBufferView(1, m_metaCB[frameIndex]->GetAddress());
+    ComPtr<ID3DBlob> serialized;
+    ComPtr<ID3DBlob> errors;
+    if (FAILED(D3D12SerializeRootSignature(&rootDesc, D3D_ROOT_SIGNATURE_VERSION_1, serialized.GetAddressOf(), errors.GetAddressOf())))
+    {
+        if (errors)
+        {
+            printf("Compute root signature error: %s\n", (char*)errors->GetBufferPointer());
+        }
+        return;
+    }
+    HRESULT hrRoot = device->CreateRootSignature(0, serialized->GetBufferPointer(), serialized->GetBufferSize(), IID_PPV_ARGS(m_computeRootSignature.ReleaseAndGetAddressOf()));
+    if (FAILED(hrRoot))
+    {
+        printf("FluidSystem: コンピュート用ルートシグネチャ生成に失敗しました\n");
+        m_gpuAvailable = false;
+        return;
+    }
 
-    // フルスクリーン三角形を描画してメタボールのスクリーンスペースレイマーチを実行
-    cmd->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-    cmd->DrawInstanced(3, 1, 0, 0);
+    m_buildGridPipeline = std::make_unique<ComputePipelineState>();
+    m_buildGridPipeline->SetDevice(device);
+    m_buildGridPipeline->SetRootSignature(m_computeRootSignature.Get());
+    m_buildGridPipeline->SetCS(L"BuildGridCS.cso");
+    if (!m_buildGridPipeline->Create())
+    {
+        m_buildGridPipeline.reset();
+        m_particlePipeline.reset();
+        m_gpuAvailable = false;
+        return;
+    }
+
+    m_particlePipeline = std::make_unique<ComputePipelineState>();
+    m_particlePipeline->SetDevice(device);
+    m_particlePipeline->SetRootSignature(m_computeRootSignature.Get());
+    m_particlePipeline->SetCS(L"ParticleCS.cso");
+    if (!m_particlePipeline->Create())
+    {
+        m_particlePipeline.reset();
+        m_gpuAvailable = false;
+        return;
+    }
+
+    m_gpuReadIndex = 0;
+    m_pendingReadback = false;
+    m_gpuAvailable = true;
+    m_gpuDirty = true;
+}
+
+void FluidSystem::UpdateGridSettings()
+{
+    float cellSize = std::max(0.02f, m_material.smoothingRadius);
+    m_spatialGrid.SetCellSize(cellSize);
+
+    float width = m_boundsMax.x - m_boundsMin.x;
+    float height = m_boundsMax.y - m_boundsMin.y;
+    float depth = m_boundsMax.z - m_boundsMin.z;
+
+    m_gridDim.x = std::max<UINT>(1u, static_cast<UINT>(std::ceil(width / cellSize)));
+    m_gridDim.y = std::max<UINT>(1u, static_cast<UINT>(std::ceil(height / cellSize)));
+    m_gridDim.z = std::max<UINT>(1u, static_cast<UINT>(std::ceil(depth / cellSize)));
 }


### PR DESCRIPTION
## Summary
- FluidSystem を全面刷新し、CPU/GPU 切り替え、マテリアル変更、粒子生成・削除、集束/発散操作などゲーム向けの操作 API を整備
- CPU シミュレーションを空間グリッドベースの PBF + XSPH で再実装し、安定性と境界処理を強化
- GPU 側の計算/描画パイプラインを再構築し、UAV ディスクリプタ登録や各種バッファの再生成ロジックを追加

## Testing
- Not run (環境に依存するため未実行)


------
https://chatgpt.com/codex/tasks/task_e_68d492e1ac708332891a389cd0c89666