### PR TITLE
Fix GPU fluid compute to use dedicated command list

### DIFF
--- a/DirectX12/FluidSystem.h
+++ b/DirectX12/FluidSystem.h
@@ -11,6 +11,7 @@
 #include <array>
 #include <memory>
 #include <vector>
+#include <Windows.h>
 
 // ================================
 //  流体マテリアルの設定パラメータ
@@ -56,6 +57,7 @@ class FluidSystem
 {
 public:
     FluidSystem();
+    ~FluidSystem();
 
     void Init(ID3D12Device* device, DXGI_FORMAT rtvFormat, UINT maxParticles, UINT threadGroupCount);
 
@@ -140,6 +142,8 @@ private:
     void CreateGPUResources(ID3D12Device* device);
     void UpdateComputeParams(float dt);
     void ResolveBounds(FluidParticle& p) const;
+    ID3D12GraphicsCommandList* BeginComputeCommandList();
+    void SubmitComputeCommandList();
 
     float EffectiveTimeStep(float dt) const;
 
@@ -178,6 +182,12 @@ private:
     Microsoft::WRL::ComPtr<ID3D12RootSignature> m_computeRootSignature;
     std::unique_ptr<ComputePipelineState> m_buildGridPipeline;
     std::unique_ptr<ComputePipelineState> m_particlePipeline;
+    Microsoft::WRL::ComPtr<ID3D12CommandAllocator> m_computeAllocator;
+    Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList> m_computeCommandList;
+    Microsoft::WRL::ComPtr<ID3D12Fence> m_computeFence;
+    HANDLE m_computeFenceEvent = nullptr;
+    UINT64 m_computeFenceValue = 0;
+    UINT64 m_lastSubmittedComputeFence = 0;
 
     // 共通設定
     FluidMaterial m_material;


### PR DESCRIPTION
## Summary
- add a dedicated compute command allocator/command list/fence so GPU fluid simulation no longer records on an already-closed graphics list
- synchronize GPU simulation results with rendering via queue waits and fence-backed readback waits, and close the fence event in a new destructor
- mark the fluid system as initialized before seeding default particles so the built-in spawn path runs during Init

## Testing
- not run (DirectX project; no automated tests available)


------
https://chatgpt.com/codex/tasks/task_e_68d49850c7808332a6abd657bb746ad5