### PR TITLE
Fix redundant resource barriers in fluid system

### DIFF
--- a/DirectX12/FluidSystem.h
+++ b/DirectX12/FluidSystem.h
@@ -162,6 +162,7 @@ private:
     DescriptorHandle* m_gpuMetaSRV = nullptr;
     DescriptorHandle* m_gpuMetaUAV = nullptr;
     DescriptorHandle* m_activeMetaSRV = nullptr;
+    D3D12_RESOURCE_STATES m_gpuMetaState = D3D12_RESOURCE_STATE_COMMON; // GPUメタデータバッファの現在ステート
 
     // GPUシミュレーション関連
     bool m_useGPU = false;
@@ -175,6 +176,8 @@ private:
     Microsoft::WRL::ComPtr<ID3D12Resource> m_gpuGridTable;
     DescriptorHandle* m_gpuGridCountUAV = nullptr;
     DescriptorHandle* m_gpuGridTableUAV = nullptr;
+    D3D12_RESOURCE_STATES m_gpuGridCountState = D3D12_RESOURCE_STATE_COMMON; // グリッドカウントバッファの現在ステート
+    D3D12_RESOURCE_STATES m_gpuGridTableState = D3D12_RESOURCE_STATE_COMMON; // グリッドテーブルバッファの現在ステート
     Microsoft::WRL::ComPtr<ID3D12Resource> m_gpuUpload;
     Microsoft::WRL::ComPtr<ID3D12Resource> m_gpuReadback;
     std::unique_ptr<ConstantBuffer> m_computeParamsCB;


### PR DESCRIPTION
## Summary
- add a helper that skips redundant resource transitions and use it for GPU particle buffers
- track the current state of meta and grid buffers to avoid issuing duplicate barriers

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d4a6c00c188332ad5ddee0942973cc