### PR TITLE
Stabilize water rendering states and camera clip data

### DIFF
--- a/DirectX12/Camera.cpp
+++ b/DirectX12/Camera.cpp
@@ -12,31 +12,34 @@ Camera::Camera() {
 }
 
 bool Camera::Init() {
-	// s—ñ•ÏŠ·
-	eyePos = DirectX::XMVectorSet(0.0f, 0.0f, 2.0f, 0.0f);		// ‹“_‚ÌˆÊ’u
-	targetPos = DirectX::XMVectorSet(0.0f, 0.0f, 0.0f, 0.0f);	// ‹“_‚ğŒü‚¯‚éÀ•W
-	upward = DirectX::XMVectorSet(0.0f, 1.0f, 0.0f, 0.0f);		// ã•ûŒü‚ğ•\‚·ƒxƒNƒgƒ‹
+	nearClip = 0.1f;
+	farClip = 1000.0f;
+
+	// è¡Œåˆ—å¤‰æ›
+	eyePos = DirectX::XMVectorSet(0.0f, 0.0f, 2.0f, 0.0f);		// è¦–ç‚¹ã®ä½ç½®
+	targetPos = DirectX::XMVectorSet(0.0f, 0.0f, 0.0f, 0.0f);	// è¦–ç‚¹ã‚’å‘ã‘ã‚‹åº§æ¨™
+	upward = DirectX::XMVectorSet(0.0f, 1.0f, 0.0f, 0.0f);		// ä¸Šæ–¹å‘ã‚’è¡¨ã™ãƒ™ã‚¯ãƒˆãƒ«
 	fov = DirectX::XMConvertToRadians(75.0);
-	// ‹–ìŠp
-	aspect = static_cast<float>(WINDOW_WIDTH) / static_cast<float>(WINDOW_HEIGHT);		// ƒAƒXƒyƒNƒg”ä
+	// è¦–é‡è§’
+	aspect = static_cast<float>(WINDOW_WIDTH) / static_cast<float>(WINDOW_HEIGHT);		// ã‚¢ã‚¹ãƒšã‚¯ãƒˆæ¯”
 
 	return 0;
 }
 
 void Camera::Update(float deltaTime) {
-	// ‰ñ“]Špiƒˆ[Eƒsƒbƒ`j
+	// å›è»¢è§’ï¼ˆãƒ¨ãƒ¼ãƒ»ãƒ”ãƒƒãƒï¼‰
 	static float yaw = 0.0f;
 	static float pitch = 0.0f;
 	static bool isDragging = false;
 	static POINT lastMouse;
 
-	// ƒ}ƒEƒX‰Eƒ{ƒ^ƒ“‚Å‰ñ“]
+	// ãƒã‚¦ã‚¹å³ãƒœã‚¿ãƒ³ã§å›è»¢
 	if (GetAsyncKeyState(VK_RBUTTON) & 0x8000) {
 		POINT curMouse;
 		GetCursorPos(&curMouse);
 
 		if (!isDragging) {
-			// ‰‰ñ‚¾‚¯ƒ}ƒEƒXˆÊ’u‚ğƒZƒbƒgiƒhƒ‰ƒbƒOŠJnj
+			// åˆå›ã ã‘ãƒã‚¦ã‚¹ä½ç½®ã‚’ã‚»ãƒƒãƒˆï¼ˆãƒ‰ãƒ©ãƒƒã‚°é–‹å§‹ï¼‰
 			lastMouse = curMouse;
 			isDragging = true;
 		}
@@ -44,7 +47,7 @@ void Camera::Update(float deltaTime) {
 		float dx = static_cast<float>(curMouse.x - lastMouse.x) * 0.005f;
 		float dy = static_cast<float>(curMouse.y - lastMouse.y) * 0.005f;
 
-		// ƒ}ƒEƒX‚Ì“®‚«‚É‰‚¶‚Äƒˆ[Eƒsƒbƒ`‚ğXVi+‚Å”½“]ó‘Ôj
+		// ãƒã‚¦ã‚¹ã®å‹•ãã«å¿œã˜ã¦ãƒ¨ãƒ¼ãƒ»ãƒ”ãƒƒãƒã‚’æ›´æ–°ï¼ˆ+ã§åè»¢çŠ¶æ…‹ï¼‰
 		yaw -= dx;
 		pitch -= dy;
 
@@ -53,15 +56,15 @@ void Camera::Update(float deltaTime) {
 		lastMouse = curMouse;
 	}
 	else {
-		isDragging = false; // ƒ{ƒ^ƒ“—£‚µ‚½‚çƒhƒ‰ƒbƒOI—¹
+	projMatrix = XMMatrixPerspectiveFovRH(fov, aspect, nearClip, farClip);
 	}
 
-	// ‰ñ“]s—ñiƒˆ[¨ƒsƒbƒ`j
+	// å›è»¢è¡Œåˆ—ï¼ˆãƒ¨ãƒ¼â†’ãƒ”ãƒƒãƒï¼‰
 	XMMATRIX rotMat = XMMatrixRotationRollPitchYaw(pitch, yaw, 0);
 	XMVECTOR forward = XMVector3TransformNormal(XMVectorSet(0, 0, -1, 0), rotMat);
 	XMVECTOR right = XMVector3TransformNormal(XMVectorSet(1, 0, 0, 0), rotMat);
 
-	// ˆÚ“®
+	// ç§»å‹•
 	if (GetAsyncKeyState('W') & 0x8000) eyePos += forward * 0.05f;
 	if (GetAsyncKeyState('S') & 0x8000) eyePos -= forward * 0.05f;
 	if (GetAsyncKeyState('A') & 0x8000) eyePos -= right * 0.05f;
@@ -69,10 +72,10 @@ void Camera::Update(float deltaTime) {
 	if (GetAsyncKeyState('E') & 0x8000) eyePos += XMVectorSet(0, 1, 0, 0) * 0.05f;
 	if (GetAsyncKeyState('Q') & 0x8000) eyePos -= XMVectorSet(0, 1, 0, 0) * 0.05f;
 
-	// ƒ^[ƒQƒbƒg = ‘O•û
+	// ã‚¿ãƒ¼ã‚²ãƒƒãƒˆ = å‰æ–¹
 	targetPos = XMVectorAdd(eyePos, forward);
 
-	// ƒrƒ…[EƒvƒƒWƒFƒNƒVƒ‡ƒ“XV
+	// ãƒ“ãƒ¥ãƒ¼ãƒ»ãƒ—ãƒ­ã‚¸ã‚§ã‚¯ã‚·ãƒ§ãƒ³æ›´æ–°
 	viewMatrix = XMMatrixLookAtRH(eyePos, targetPos, XMVectorSet(0, 1, 0, 0));
 	projMatrix = XMMatrixPerspectiveFovRH(fov, aspect, 0.1f, 1000.0f);
 
@@ -80,16 +83,16 @@ void Camera::Update(float deltaTime) {
 
 DirectX::XMFLOAT4X4 Camera::GetInvViewProj() const
 {
-	// View~Proj s—ñ‚ğŠ|‚¯‚é
+	// ViewÃ—Proj è¡Œåˆ—ã‚’æ›ã‘ã‚‹
 	XMMATRIX view = GetViewMatrix();
 	XMMATRIX proj = GetProjMatrix();
 	XMMATRIX viewProj = XMMatrixMultiply(view, proj);
 
-	// ‹ts—ñ‚ğŒvZ
+	// é€†è¡Œåˆ—ã‚’è¨ˆç®—
 	XMVECTOR det;
 	XMMATRIX invVP = XMMatrixInverse(&det, viewProj);
 
-	// Ši”[‚µ‚Ä•Ô‚·
+	// æ ¼ç´ã—ã¦è¿”ã™
 	DirectX::XMFLOAT4X4 out;
 	XMStoreFloat4x4(&out, invVP);
 	return out;

--- a/DirectX12/Camera.h
+++ b/DirectX12/Camera.h
@@ -10,14 +10,24 @@ private:
 	float posY = 0.0f;
 	float posZ = 0.0f;
 
+	// ß•ÊEÊi_OpÌƒNbvj
+	float nearClip = 0.1f;
+	float farClip = 1000.0f;
 
 	DirectX::XMVECTOR eyePos;
 	DirectX::XMVECTOR targetPos;
 	DirectX::XMVECTOR upward;
 	float fov;
 	float aspect;
-	float yaw = 0.0f;   // ¶‰E‰ñ“]iY²j
-	float pitch = 0.0f; // ã‰º‰ñ“]iX²j
+	float GetNearClip() const { return nearClip; }
+	float GetFarClip() const { return farClip; }
+	void SetClipPlanes(float nearPlane, float farPlane)
+	{
+		nearClip = nearPlane;
+		farClip = farPlane;
+	}
+	float yaw = 0.0f;   // å·¦å³å›è»¢ï¼ˆYè»¸ï¼‰
+	float pitch = 0.0f; // ä¸Šä¸‹å›è»¢ï¼ˆXè»¸ï¼‰
 
 	DirectX::XMMATRIX viewMatrix;
 	DirectX::XMMATRIX projMatrix;

--- a/DirectX12/DirectX12.vcxproj
+++ b/DirectX12/DirectX12.vcxproj
@@ -178,6 +178,8 @@
     <ClCompile Include="Texture2D.cpp" />
     <ClCompile Include="TitleScene.cpp" />
     <ClCompile Include="VertexBuffer.cpp" />
+    <ClCompile Include="Source\Rendering\FluidWaterRenderer.cpp" />
+    <ClCompile Include="Source\Rendering\SSRRenderer.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="App.h" />
@@ -210,6 +212,8 @@
     <ClInclude Include="SphereMeshGenerator.h" />
     <ClInclude Include="SpatialGrid.h" />
     <ClInclude Include="Texture2D.h" />
+    <ClInclude Include="Source\Rendering\FluidWaterRenderer.h" />
+    <ClInclude Include="Source\Rendering\SSRRenderer.h" />
     <ClInclude Include="TitleScene.h" />
     <ClInclude Include="VertexBuffer.h" />
   </ItemGroup>

--- a/DirectX12/DirectX12.vcxproj.filters
+++ b/DirectX12/DirectX12.vcxproj.filters
@@ -61,6 +61,12 @@
     <Filter Include="ヘッダー ファイル\System\DescriptorHeap">
       <UniqueIdentifier>{2f229c0a-2929-458c-b0f9-f271e89040ba}</UniqueIdentifier>
     </Filter>
+    <Filter Include="ソース ファイル\System\Rendering">
+      <UniqueIdentifier>{6d4db51b-2e3b-4e08-95a0-9fa2890edb8f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ヘッダー ファイル\System\Rendering">
+      <UniqueIdentifier>{d1f09706-2b9f-45f5-8d86-5d926d6f2a8d}</UniqueIdentifier>
+    </Filter>
     <Filter Include="リソース ファイル\PixelShader">
       <UniqueIdentifier>{8117fc0b-0b3b-4795-81f3-66d4d1710778}</UniqueIdentifier>
     </Filter>
@@ -173,6 +179,12 @@
     </ClInclude>
     <ClInclude Include="VertexBuffer.h">
       <Filter>ヘッダー ファイル\System\Buffer</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\Rendering\FluidWaterRenderer.h">
+      <Filter>ヘッダー ファイル\System\Rendering</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\Rendering\SSRRenderer.h">
+      <Filter>ヘッダー ファイル\System\Rendering</Filter>
     </ClInclude>
     <ClInclude Include="ConstantBuffer.h">
       <Filter>ヘッダー ファイル\System\Buffer</Filter>

--- a/DirectX12/FluidSystem.h
+++ b/DirectX12/FluidSystem.h
@@ -81,6 +81,10 @@ public:
         const DirectX::XMFLOAT3& camPos,
         float isoLevel);
 
+    DescriptorHandle* ActiveMetaSRV() const { return m_activeMetaSRV; }
+    UINT ActiveParticleCount() const { return m_particleCount; }
+    float RenderParticleRadius() const { return m_material.renderRadius; }
+
     void StartDrag(int, int, class Camera*) {}
     void Drag(int, int, class Camera*) {}
     void EndDrag() {}

--- a/DirectX12/GameScene.h
+++ b/DirectX12/GameScene.h
@@ -3,25 +3,34 @@
 #include <DirectXMath.h>
 #include <vector>
 #include <d3dx12.h>
-#include "IActor.h"      // IActor の定義
+#include "IActor.h"      // IActor ﾌ蛋
 
 #include "Camera.h"
 #include "Particle.h"
 #include "FluidSystem.h"
 
+#include "Source/Rendering/FluidWaterRenderer.h"
+#include "Source/Rendering/SSRRenderer.h"
 class GameScene : public BaseScene
 {
 private:
 	ConstantBuffer* constantBuffer[Engine::FRAME_BUFFER_COUNT];
     ID3D12GraphicsCommandList* commandList = nullptr;
 
-    // ===== オブジェクト =====
+    // ===== IuWFNg =====
     FluidSystem  m_fluid;
     std::unique_ptr<Particle> particle;
+    std::unique_ptr<FluidWaterRenderer> m_fluidRenderer;
+    std::unique_ptr<SSRRenderer> m_ssrRenderer;
+    FluidDebugView m_currentDebug = FluidDebugView::Composite;
+    int m_ssrQuality = 2;
+    bool m_usePlanarReflection = false;
+    bool m_gridDebug = false;
+    uint32_t m_downsampleStep = 1;
     std::vector<std::unique_ptr<IActor>> m_objects;
     //Generator                          m_generator;
 
-    // 現在のシーンを指すグローバルポインタ
+    // ﾝのシ[wO[o|C^
     static GameScene* g_pCurrentScene;
 public:
 	GameScene(Game* game);
@@ -30,7 +39,7 @@ public:
 	void Update(float deltaTime) override;
 	void Draw() override;
 
-	// シーン内に生成するための静的メソッド
+	// V[ﾉ宣たﾟの静的\bh
     template<typename T, typename... Args>
     static void Spawn(Args&&... args) {
         if (g_pCurrentScene) {
@@ -44,7 +53,7 @@ public:
     }
 
 private:
-	// シーン内での生成と破棄を実装するメソッド
+	// V[ﾅの脆破驛―bh
     template<typename T, typename... Args>
     void SpawnImpl(Args&&... args) {
         m_objects.push_back(

--- a/DirectX12/Shaders/Fluid/BilateralBlurX.hlsl
+++ b/DirectX12/Shaders/Fluid/BilateralBlurX.hlsl
@@ -1,0 +1,36 @@
+Texture2D<float> g_InputDepth : register(t0);
+SamplerState g_LinearClamp : register(s0);
+RWTexture2D<float> g_OutputDepth : register(u0);
+
+[numthreads(8, 8, 1)]
+void CSMain(uint3 dispatchThreadId : SV_DispatchThreadID)
+{
+    uint2 coord = dispatchThreadId.xy;
+    uint width, height;
+    g_InputDepth.GetDimensions(width, height);
+    if (coord.x >= width || coord.y >= height)
+    {
+        return;
+    }
+
+    float center = g_InputDepth.Load(int3(coord, 0));
+    float sigmaSpatial = 2.0f;
+    float sigmaRange = 0.5f;
+    float sum = 0.0f;
+    float weightSum = 0.0f;
+
+    [unroll]
+    for (int offset = -3; offset <= 3; ++offset)
+    {
+        int sampleX = clamp(int(coord.x) + offset, 0, int(width) - 1);
+        uint2 sampleCoord = uint2(sampleX, coord.y);
+        float sampleDepth = g_InputDepth.Load(int3(sampleCoord, 0));
+        float spatial = exp(- (offset * offset) / (2.0f * sigmaSpatial * sigmaSpatial));
+        float range = exp(- pow(sampleDepth - center, 2.0f) / (2.0f * sigmaRange * sigmaRange));
+        float weight = spatial * range;
+        sum += sampleDepth * weight;
+        weightSum += weight;
+    }
+
+    g_OutputDepth[coord] = (weightSum > 0.0f) ? (sum / weightSum) : center;
+}

--- a/DirectX12/Shaders/Fluid/BilateralBlurY.hlsl
+++ b/DirectX12/Shaders/Fluid/BilateralBlurY.hlsl
@@ -1,0 +1,36 @@
+Texture2D<float> g_InputDepth : register(t0);
+SamplerState g_LinearClamp : register(s0);
+RWTexture2D<float> g_OutputDepth : register(u0);
+
+[numthreads(8, 8, 1)]
+void CSMain(uint3 dispatchThreadId : SV_DispatchThreadID)
+{
+    uint2 coord = dispatchThreadId.xy;
+    uint width, height;
+    g_InputDepth.GetDimensions(width, height);
+    if (coord.x >= width || coord.y >= height)
+    {
+        return;
+    }
+
+    float center = g_InputDepth.Load(int3(coord, 0));
+    float sigmaSpatial = 2.0f;
+    float sigmaRange = 0.5f;
+    float sum = 0.0f;
+    float weightSum = 0.0f;
+
+    [unroll]
+    for (int offset = -3; offset <= 3; ++offset)
+    {
+        int sampleY = clamp(int(coord.y) + offset, 0, int(height) - 1);
+        uint2 sampleCoord = uint2(coord.x, sampleY);
+        float sampleDepth = g_InputDepth.Load(int3(sampleCoord, 0));
+        float spatial = exp(- (offset * offset) / (2.0f * sigmaSpatial * sigmaSpatial));
+        float range = exp(- pow(sampleDepth - center, 2.0f) / (2.0f * sigmaRange * sigmaRange));
+        float weight = spatial * range;
+        sum += sampleDepth * weight;
+        weightSum += weight;
+    }
+
+    g_OutputDepth[coord] = (weightSum > 0.0f) ? (sum / weightSum) : center;
+}

--- a/DirectX12/Shaders/Fluid/CompositeWaterPS.hlsl
+++ b/DirectX12/Shaders/Fluid/CompositeWaterPS.hlsl
@@ -1,0 +1,90 @@
+cbuffer CameraCB : register(b0)
+{
+    float4x4 g_View;
+    float4x4 g_Proj;
+    float2   g_ScreenSize;
+    float2   g_InvScreenSize;
+    float    g_NearZ;
+    float    g_FarZ;
+    float3   g_IorF0;
+    float    g_Absorb;
+    uint4    g_Options;
+};
+
+Texture2D<float4> g_SceneColor : register(t0);
+Texture2D<float>  g_SceneDepth : register(t1);
+Texture2D<float>  g_FluidDepth : register(t2);
+Texture2D<float>  g_FluidThickness : register(t3);
+Texture2D<float4> g_FluidNormal : register(t4);
+Texture2D<float4> g_SSRColor : register(t5);
+SamplerState g_LinearClamp : register(s0);
+
+struct PSIn
+{
+    float4 position : SV_POSITION;
+    float2 uv       : TEXCOORD0;
+};
+
+float3 ApplyBeerLambert(float3 color, float thickness)
+{
+    float3 absorb = float3(g_Absorb, g_Absorb * 0.7f, g_Absorb * 0.5f);
+    return color * exp(-absorb * thickness);
+}
+
+float3 GetViewDir(float2 uv)
+{
+    float2 ndc = float2(uv.x * 2.0f - 1.0f, 1.0f - uv.y * 2.0f);
+    float4 clip = float4(ndc, 1.0f, 1.0f);
+    float4 view = mul(inverse(g_Proj), clip);
+    view.xyz /= max(view.w, 1e-5f);
+    return normalize(view.xyz);
+}
+
+float4 PSMain(PSIn input) : SV_TARGET
+{
+    float2 uv = input.uv;
+    float sceneDepth = g_SceneDepth.SampleLevel(g_LinearClamp, uv, 0.0f);
+    float fluidDepth = g_FluidDepth.SampleLevel(g_LinearClamp, uv, 0.0f);
+    float thickness = g_FluidThickness.SampleLevel(g_LinearClamp, uv, 0.0f);
+    float4 normalSample = g_FluidNormal.SampleLevel(g_LinearClamp, uv, 0.0f);
+    float3 normal = normalize(normalSample.xyz * 2.0f - 1.0f);
+
+    float4 sceneColor = g_SceneColor.SampleLevel(g_LinearClamp, uv, 0.0f);
+    float4 ssrColor = g_SSRColor.SampleLevel(g_LinearClamp, uv, 0.0f);
+
+    if (thickness <= 1e-3f)
+    {
+        return sceneColor;
+    }
+
+    float3 viewDir = normalize(-GetViewDir(uv));
+    float cosTheta = saturate(dot(normal, viewDir));
+    float3 fresnel = g_IorF0 + (1.0f - g_IorF0) * pow(1.0f - cosTheta, 5.0f);
+
+    float2 refrUV = uv + normal.xy * 0.03f;
+    float3 refrColor = g_SceneColor.SampleLevel(g_LinearClamp, refrUV, 0.0f).rgb;
+    refrColor = ApplyBeerLambert(refrColor, thickness);
+
+    float3 reflectColor = ssrColor.rgb;
+    if (g_Options.z > 0.5f)
+    {
+        reflectColor = lerp(reflectColor, sceneColor.rgb, 0.3f);
+    }
+
+    float3 waterColor = lerp(refrColor, reflectColor, fresnel);
+
+    if (g_Options.x == 1)
+    {
+        waterColor = saturate(fluidDepth / g_FarZ).xxx;
+    }
+    else if (g_Options.x == 2)
+    {
+        waterColor = saturate(thickness * 0.1f).xxx;
+    }
+    else if (g_Options.x == 3)
+    {
+        waterColor = normalize(normal) * 0.5f + 0.5f;
+    }
+
+    return float4(waterColor, 1.0f);
+}

--- a/DirectX12/Shaders/Fluid/FluidDepthThicknessPS.hlsl
+++ b/DirectX12/Shaders/Fluid/FluidDepthThicknessPS.hlsl
@@ -1,0 +1,96 @@
+cbuffer CameraCB : register(b0)
+{
+    float4x4 g_View;
+    float4x4 g_Proj;
+    float2   g_ScreenSize;
+    float2   g_InvScreenSize;
+    float    g_NearZ;
+    float    g_FarZ;
+    float3   g_IorF0;
+    float    g_Absorb;
+    uint4    g_Options;
+};
+
+cbuffer FluidParams : register(b1)
+{
+    float g_Radius;
+    float g_ThicknessScale;
+    uint  g_ParticleCount;
+    float g_Downsample;
+};
+
+struct ParticleInstance
+{
+    float3 position;
+    float  radius;
+};
+StructuredBuffer<ParticleInstance> g_Particles : register(t0);
+SamplerState g_LinearClamp : register(s0);
+
+struct VSOut
+{
+    float4 position : SV_POSITION;
+    float2 uv       : TEXCOORD0;
+};
+
+struct PSOut
+{
+    float thickness : SV_Target0;
+    float depth     : SV_Target1;
+};
+
+float3 ReconstructRay(float2 uv)
+{
+    float2 ndc = float2(uv.x * 2.0f - 1.0f, 1.0f - uv.y * 2.0f);
+    float4 clip = float4(ndc, 1.0f, 1.0f);
+    float4 view = mul(inverse(g_Proj), clip);
+    view.xyz /= max(view.w, 1e-5f);
+    return normalize(view.xyz);
+}
+
+PSOut PSMain(VSOut input)
+{
+    PSOut o;
+    o.thickness = 0.0f;
+    float minDepth = g_FarZ;
+
+    float3 rayDir = ReconstructRay(input.uv);
+    float3 rayOrigin = float3(0.0f, 0.0f, 0.0f);
+
+    [loop]
+    for (uint i = 0; i < g_ParticleCount; ++i)
+    {
+        ParticleInstance instance = g_Particles[i];
+        float4 viewPos4 = mul(g_View, float4(instance.position, 1.0f));
+        float3 viewPos = viewPos4.xyz;
+
+        float radius = max(instance.radius, g_Radius);
+        float3 toCenter = rayOrigin - viewPos;
+        float b = dot(toCenter, rayDir);
+        float c = dot(toCenter, toCenter) - radius * radius;
+        float discriminant = b * b - c;
+        if (discriminant < 0.0f)
+        {
+            continue;
+        }
+
+        float sqrtDisc = sqrt(discriminant);
+        float t0 = -b - sqrtDisc;
+        float t1 = -b + sqrtDisc;
+        if (t1 <= 0.0f)
+        {
+            continue;
+        }
+
+        float nearT = max(t0, 0.0f);
+        float farT = max(t1, 0.0f);
+        float segment = max(farT - nearT, 0.0f);
+        o.thickness += segment;
+        minDepth = min(minDepth, nearT);
+    }
+
+    o.thickness *= g_ThicknessScale;
+    o.thickness = min(o.thickness, 50.0f);
+    o.depth = (minDepth >= g_FarZ) ? g_FarZ : minDepth;
+    return o;
+}

--- a/DirectX12/Shaders/Fluid/FluidDepthThicknessVS.hlsl
+++ b/DirectX12/Shaders/Fluid/FluidDepthThicknessVS.hlsl
@@ -1,0 +1,15 @@
+// 画面全面を覆う三角形を生成する頂点シェーダ
+struct VSOut
+{
+    float4 position : SV_POSITION;
+    float2 uv       : TEXCOORD0;
+};
+
+VSOut VSMain(uint vertexId : SV_VertexID)
+{
+    VSOut o;
+    float2 pos = float2((vertexId << 1) & 2, vertexId & 2);
+    o.position = float4(pos * float2(2, -2) + float2(-1, 1), 0, 1);
+    o.uv = float2(pos.x * 0.5f, pos.y * 0.5f);
+    return o;
+}

--- a/DirectX12/Shaders/Fluid/ReconstructNormalCS.hlsl
+++ b/DirectX12/Shaders/Fluid/ReconstructNormalCS.hlsl
@@ -1,0 +1,25 @@
+Texture2D<float> g_Depth : register(t0);
+RWTexture2D<float4> g_Normal : register(u0);
+
+[numthreads(8, 8, 1)]
+void CSMain(uint3 dispatchThreadId : SV_DispatchThreadID)
+{
+    uint2 coord = dispatchThreadId.xy;
+    uint width, height;
+    g_Depth.GetDimensions(width, height);
+    if (coord.x >= width || coord.y >= height)
+    {
+        return;
+    }
+
+    float center = g_Depth.Load(int3(coord, 0));
+    float depthRight = g_Depth.Load(int3(uint2(min(coord.x + 1, width - 1), coord.y), 0));
+    float depthUp = g_Depth.Load(int3(uint2(coord.x, min(coord.y + 1, height - 1)), 0));
+
+    float3 dx = float3(1.0f, 0.0f, depthRight - center);
+    float3 dy = float3(0.0f, 1.0f, depthUp - center);
+    float3 normal = normalize(cross(dx, dy));
+    normal = (normal * 0.5f) + 0.5f;
+
+    g_Normal[coord] = float4(normal, 1.0f);
+}

--- a/DirectX12/Shaders/SSR/SSR_PS.hlsl
+++ b/DirectX12/Shaders/SSR/SSR_PS.hlsl
@@ -1,0 +1,88 @@
+cbuffer CameraCB : register(b0)
+{
+    float4x4 g_View;
+    float4x4 g_Proj;
+    float2   g_ScreenSize;
+    float2   g_InvScreenSize;
+    float    g_NearZ;
+    float    g_FarZ;
+    float3   g_IorF0;
+    float    g_Absorb;
+    uint4    g_Options;
+};
+
+Texture2D<float4> g_SceneColor : register(t0);
+Texture2D<float>  g_SceneDepth : register(t1);
+Texture2D<float4> g_Normal     : register(t2);
+SamplerState g_LinearClamp : register(s0);
+
+struct PSIn
+{
+    float4 position : SV_POSITION;
+    float2 uv       : TEXCOORD0;
+};
+
+float3 ReconstructPosition(float2 uv, float depth)
+{
+    float2 ndc = float2(uv.x * 2.0f - 1.0f, 1.0f - uv.y * 2.0f);
+    float4 clip = float4(ndc, 1.0f, 1.0f);
+    float4 view = mul(inverse(g_Proj), clip);
+    view.xyz /= max(view.w, 1e-5f);
+    return normalize(view.xyz) * depth;
+}
+
+float4 PSMain(PSIn input) : SV_TARGET
+{
+    float2 uv = input.uv;
+    float depth = g_SceneDepth.SampleLevel(g_LinearClamp, uv, 0.0f);
+    if (depth >= g_FarZ - 1e-3f)
+    {
+        return float4(0, 0, 0, 1);
+    }
+
+    float3 normal = normalize(g_Normal.SampleLevel(g_LinearClamp, uv, 0.0f).xyz * 2.0f - 1.0f);
+    float3 viewPos = ReconstructPosition(uv, depth);
+    float3 viewDir = normalize(-viewPos);
+    float3 reflectDir = normalize(reflect(viewDir, normal));
+
+    float3 origin = viewPos;
+    float stepLength = 1.0f;
+    uint maxSteps = max(8u, g_Options.y * 8u);
+    float3 hitColor = float3(0.0f, 0.0f, 0.0f);
+    bool hit = false;
+
+    [loop]
+    for (uint step = 0; step < maxSteps; ++step)
+    {
+        float travel = (step + 1) * stepLength;
+        float3 samplePos = origin + reflectDir * travel;
+        if (samplePos.z < g_NearZ || samplePos.z > g_FarZ)
+        {
+            break;
+        }
+
+        float4 proj = mul(g_Proj, float4(samplePos, 1.0f));
+        float2 sampleUV = proj.xy / proj.w * float2(0.5f, -0.5f) + float2(0.5f, 0.5f);
+        if (sampleUV.x < 0.0f || sampleUV.x > 1.0f || sampleUV.y < 0.0f || sampleUV.y > 1.0f)
+        {
+            continue;
+        }
+
+        float sceneDepth = g_SceneDepth.SampleLevel(g_LinearClamp, sampleUV, 0.0f);
+        float depthDiff = sceneDepth - samplePos.z;
+        if (abs(depthDiff) < 0.8f)
+        {
+            hitColor = g_SceneColor.SampleLevel(g_LinearClamp, sampleUV, 0.0f).rgb;
+            hit = true;
+            break;
+        }
+    }
+
+    if (!hit)
+    {
+        float3 envColor = float3(0.2f, 0.35f, 0.45f);
+        return float4(envColor, 1.0f);
+    }
+
+    return float4(hitColor, 1.0f);
+}

--- a/DirectX12/Source/Rendering/FluidWaterRenderer.cpp
+++ b/DirectX12/Source/Rendering/FluidWaterRenderer.cpp
@@ -1,0 +1,756 @@
+#include "FluidWaterRenderer.h"
+#include "Camera.h"
+#include "FluidSystem.h"
+#include "Engine.h"
+#include <d3dx12.h>
+#include <d3dcompiler.h>
+#include <DirectXMath.h>
+#include <algorithm>
+
+#pragma comment(lib, "d3dcompiler.lib")
+
+using namespace DirectX;
+using Microsoft::WRL::ComPtr;
+
+namespace
+{
+    // ================================
+    // HLSLコンパイルのユーティリティ
+    // ================================
+    bool CompileShader(const std::wstring& path, const char* entry, const char* target, ComPtr<ID3DBlob>& blob)
+    {
+        UINT flags = D3DCOMPILE_ENABLE_STRICTNESS;
+    #if defined(_DEBUG)
+        flags |= D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
+    #endif
+        ComPtr<ID3DBlob> errors;
+        HRESULT hr = D3DCompileFromFile(path.c_str(), nullptr, D3D_COMPILE_STANDARD_FILE_INCLUDE,
+            entry, target, flags, 0, blob.GetAddressOf(), errors.GetAddressOf());
+        if (FAILED(hr))
+        {
+            if (errors)
+            {
+                OutputDebugStringA((char*)errors->GetBufferPointer());
+            }
+            return false;
+        }
+        return true;
+    }
+
+    inline D3D12_STATIC_SAMPLER_DESC LinearClampSampler()
+    {
+        D3D12_STATIC_SAMPLER_DESC desc{};
+        desc.Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
+        desc.AddressU = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
+        desc.AddressV = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
+        desc.AddressW = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
+        desc.MaxLOD = D3D12_FLOAT32_MAX;
+        desc.ShaderRegister = 0;
+        desc.RegisterSpace = 0;
+        desc.ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
+        return desc;
+    }
+}
+
+FluidWaterRenderer::FluidWaterRenderer() = default;
+
+bool FluidWaterRenderer::Init(ID3D12Device* device, UINT width, UINT height)
+{
+    if (!device || m_initialized)
+    {
+        return false;
+    }
+
+    m_device = device;
+    m_width = width;
+    m_height = height;
+
+    CreateHeaps(device);
+    CreateConstantBuffers(device);
+    CreateRenderTargets(device);
+    CreateRootSignatures(device);
+    CreatePipelineStates(device);
+    CreateSamplers(device);
+
+    m_initialized = true;
+    return true;
+}
+
+void FluidWaterRenderer::Resize(UINT width, UINT height)
+{
+    if (!m_initialized || (width == m_width && height == m_height))
+    {
+        return;
+    }
+
+    m_width = width;
+    m_height = height;
+
+    CreateRenderTargets(m_device);
+}
+
+void FluidWaterRenderer::SetDownsample(uint32_t step)
+{
+    step = std::max<uint32_t>(1u, std::min<uint32_t>(4u, step));
+    if (m_downsample == step)
+    {
+        return;
+    }
+    m_downsample = step;
+    CreateRenderTargets(m_device);
+}
+
+void FluidWaterRenderer::BeginSceneRender(ID3D12GraphicsCommandList* cmd)
+{
+    if (!cmd)
+    {
+        return;
+    }
+
+    ID3D12DescriptorHeap* heaps[] = { m_srvUavHeap.Get(), m_samplerHeap.Get() };
+    cmd->SetDescriptorHeaps(2, heaps);
+
+    // ダウンサンプル解像度のビューポート／シザーを設定
+    UINT targetWidth = std::max<UINT>(1u, m_width / m_downsample);
+    UINT targetHeight = std::max<UINT>(1u, m_height / m_downsample);
+    D3D12_VIEWPORT viewport{ 0.0f, 0.0f, static_cast<float>(targetWidth), static_cast<float>(targetHeight), 0.0f, 1.0f };
+    D3D12_RECT scissor{ 0, 0, static_cast<LONG>(targetWidth), static_cast<LONG>(targetHeight) };
+    cmd->RSSetViewports(1, &viewport);
+    cmd->RSSetScissorRects(1, &scissor);
+
+    // シーンカラー／深度をレンダーターゲットに遷移
+    Transition(cmd, m_sceneColor.Get(), m_sceneColorState, D3D12_RESOURCE_STATE_RENDER_TARGET);
+    Transition(cmd, m_sceneDepthBuffer.Get(), m_sceneDepthState, D3D12_RESOURCE_STATE_DEPTH_WRITE);
+
+    // RTV/DSVを設定
+    cmd->OMSetRenderTargets(1, &m_sceneColorRTV, FALSE, &m_sceneDepthDSV);
+
+    const float clearColor[4] = { 0.0f, 0.0f, 0.0f, 1.0f };
+    cmd->ClearRenderTargetView(m_sceneColorRTV, clearColor, 0, nullptr);
+    cmd->ClearDepthStencilView(m_sceneDepthDSV, D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
+}
+
+void FluidWaterRenderer::EndSceneRender(ID3D12GraphicsCommandList* cmd)
+{
+    if (!cmd)
+    {
+        return;
+    }
+
+    // 描画結果をシェーダ読み込み可能に戻す
+    Transition(cmd, m_sceneColor.Get(), m_sceneColorState, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+    Transition(cmd, m_sceneDepthBuffer.Get(), m_sceneDepthState, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+
+    // バックバッファへ戻す
+    auto backBuffer = g_Engine->CurrentBackBufferView();
+    auto defaultDSV = g_Engine->DepthStencilView();
+    cmd->OMSetRenderTargets(1, &backBuffer, FALSE, &defaultDSV);
+
+    // 元の解像度にビューポート／シザーを戻す
+    D3D12_VIEWPORT viewport{ 0.0f, 0.0f, static_cast<float>(g_Engine->FrameBufferWidth()), static_cast<float>(g_Engine->FrameBufferHeight()), 0.0f, 1.0f };
+    D3D12_RECT scissor{ 0, 0, static_cast<LONG>(g_Engine->FrameBufferWidth()), static_cast<LONG>(g_Engine->FrameBufferHeight()) };
+    cmd->RSSetViewports(1, &viewport);
+    cmd->RSSetScissorRects(1, &scissor);
+}
+
+void FluidWaterRenderer::RenderDepthThickness(ID3D12GraphicsCommandList* cmd, const Camera& camera, FluidSystem& fluid)
+{
+    if (!m_initialized || !cmd)
+    {
+        return;
+    }
+
+    UpdateCameraConstants(camera);
+    UpdateFluidConstants(fluid);
+
+    auto particleSRV = fluid.ActiveMetaSRV();
+    if (particleSRV)
+    {
+        m_device->CopyDescriptorsSimple(1, CpuHandle(2), particleSRV->HandleCPU, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+    }
+
+    // FluidDepth/Thicknessをレンダーターゲットへ遷移
+    Transition(cmd, m_fluidDepth.Get(), m_fluidDepthState, D3D12_RESOURCE_STATE_RENDER_TARGET);
+    Transition(cmd, m_fluidThickness.Get(), m_fluidThicknessState, D3D12_RESOURCE_STATE_RENDER_TARGET);
+    Transition(cmd, m_fluidDepthStencil.Get(), m_fluidDepthStencilState, D3D12_RESOURCE_STATE_DEPTH_WRITE);
+
+    ID3D12DescriptorHeap* heaps[] = { m_srvUavHeap.Get(), m_samplerHeap.Get() };
+    cmd->SetDescriptorHeaps(2, heaps);
+
+    cmd->SetGraphicsRootSignature(m_depthThicknessRS.Get());
+    cmd->SetPipelineState(m_depthThicknessPSO.Get());
+
+    UINT targetWidth = std::max<UINT>(1u, m_width / m_downsample);
+    UINT targetHeight = std::max<UINT>(1u, m_height / m_downsample);
+    D3D12_VIEWPORT viewport{ 0.0f, 0.0f, static_cast<float>(targetWidth), static_cast<float>(targetHeight), 0.0f, 1.0f };
+    D3D12_RECT scissor{ 0, 0, static_cast<LONG>(targetWidth), static_cast<LONG>(targetHeight) };
+    cmd->RSSetViewports(1, &viewport);
+    cmd->RSSetScissorRects(1, &scissor);
+
+    D3D12_CPU_DESCRIPTOR_HANDLE rtHandles[2] = { m_fluidThicknessRTV, m_fluidDepthRTV };
+    cmd->OMSetRenderTargets(2, rtHandles, FALSE, &m_fluidDSV);
+
+    float clearThick[4] = { 0,0,0,0 };
+    cmd->ClearRenderTargetView(m_fluidThicknessRTV, clearThick, 0, nullptr);
+    cmd->ClearRenderTargetView(m_fluidDepthRTV, clearThick, 0, nullptr);
+    cmd->ClearDepthStencilView(m_fluidDSV, D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
+
+    cmd->SetGraphicsRootConstantBufferView(0, m_cameraCB->GetAddress());
+    cmd->SetGraphicsRootConstantBufferView(1, m_fluidCB->GetAddress());
+    cmd->SetGraphicsRootDescriptorTable(2, GpuHandle(2));
+    cmd->SetGraphicsRootDescriptorTable(3, m_samplerHeap->GetGPUDescriptorHandleForHeapStart());
+
+    cmd->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+    cmd->DrawInstanced(3, 1, 0, 0);
+
+    // 描画後はSRV状態に戻す
+    Transition(cmd, m_fluidThickness.Get(), m_fluidThicknessState, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+    Transition(cmd, m_fluidDepth.Get(), m_fluidDepthState, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+}
+
+void FluidWaterRenderer::BlurAndNormal(ID3D12GraphicsCommandList* cmd)
+{
+    if (!m_initialized || !cmd)
+    {
+        return;
+    }
+
+    ID3D12DescriptorHeap* heaps[] = { m_srvUavHeap.Get(), m_samplerHeap.Get() };
+    cmd->SetDescriptorHeaps(2, heaps);
+
+    // Blur X : Depth -> DepthBlur
+    D3D12_UNORDERED_ACCESS_VIEW_DESC blurUav{};
+    blurUav.Format = DXGI_FORMAT_R32_FLOAT;
+    blurUav.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE2D;
+    m_device->CreateUnorderedAccessView(m_fluidDepthBlur.Get(), nullptr, &blurUav, CpuHandle(11));
+    Transition(cmd, m_fluidDepth.Get(), m_fluidDepthState, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+    Transition(cmd, m_fluidDepthBlur.Get(), m_fluidDepthBlurState, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+
+    cmd->SetComputeRootSignature(m_blurRS.Get());
+    cmd->SetPipelineState(m_blurXPSO.Get());
+    cmd->SetComputeRootDescriptorTable(0, GpuHandle(5));
+    cmd->SetComputeRootDescriptorTable(1, m_samplerHeap->GetGPUDescriptorHandleForHeapStart());
+    cmd->SetComputeRootDescriptorTable(2, GpuHandle(11));
+
+    UINT dispatchX = (m_width / m_downsample + 7) / 8;
+    UINT dispatchY = (m_height / m_downsample + 7) / 8;
+    cmd->Dispatch(dispatchX, dispatchY, 1);
+
+    auto uavBarrier = CD3DX12_RESOURCE_BARRIER::UAV(m_fluidDepthBlur.Get());
+    cmd->ResourceBarrier(1, &uavBarrier);
+
+    Transition(cmd, m_fluidDepthBlur.Get(), m_fluidDepthBlurState, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+    Transition(cmd, m_fluidDepth.Get(), m_fluidDepthState, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+
+    // Blur Y : DepthBlur -> Depth
+    D3D12_SHADER_RESOURCE_VIEW_DESC blurSrv{};
+    blurSrv.Format = DXGI_FORMAT_R32_FLOAT;
+    blurSrv.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+    blurSrv.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+    blurSrv.Texture2D.MipLevels = 1;
+    m_device->CreateShaderResourceView(m_fluidDepthBlur.Get(), &blurSrv, CpuHandle(11));
+
+    cmd->SetPipelineState(m_blurYPSO.Get());
+    cmd->SetComputeRootDescriptorTable(0, GpuHandle(11));
+    cmd->SetComputeRootDescriptorTable(1, m_samplerHeap->GetGPUDescriptorHandleForHeapStart());
+    cmd->SetComputeRootDescriptorTable(2, GpuHandle(9));
+    cmd->Dispatch(dispatchX, dispatchY, 1);
+
+    uavBarrier = CD3DX12_RESOURCE_BARRIER::UAV(m_fluidDepth.Get());
+    cmd->ResourceBarrier(1, &uavBarrier);
+
+    Transition(cmd, m_fluidDepth.Get(), m_fluidDepthState, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+
+    // Normal reconstruct
+    Transition(cmd, m_fluidNormal.Get(), m_fluidNormalState, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+
+    cmd->SetComputeRootSignature(m_normalRS.Get());
+    cmd->SetPipelineState(m_normalPSO.Get());
+    cmd->SetComputeRootDescriptorTable(0, GpuHandle(5));
+    cmd->SetComputeRootDescriptorTable(1, GpuHandle(12));
+    cmd->Dispatch(dispatchX, dispatchY, 1);
+
+    uavBarrier = CD3DX12_RESOURCE_BARRIER::UAV(m_fluidNormal.Get());
+    cmd->ResourceBarrier(1, &uavBarrier);
+
+    Transition(cmd, m_fluidNormal.Get(), m_fluidNormalState, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+    Transition(cmd, m_fluidDepth.Get(), m_fluidDepthState, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+}
+
+void FluidWaterRenderer::Composite(ID3D12GraphicsCommandList* cmd)
+{
+    if (!m_initialized || !cmd)
+    {
+        return;
+    }
+
+    ID3D12DescriptorHeap* heaps[] = { m_srvUavHeap.Get(), m_samplerHeap.Get() };
+    cmd->SetDescriptorHeaps(2, heaps);
+
+    // シーンカラーテクスチャと深度をピクセルシェーダで読む準備
+    Transition(cmd, m_sceneColor.Get(), m_sceneColorState, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+    Transition(cmd, m_sceneDepthBuffer.Get(), m_sceneDepthState, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+    Transition(cmd, m_fluidDepth.Get(), m_fluidDepthState, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+    Transition(cmd, m_fluidThickness.Get(), m_fluidThicknessState, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+    Transition(cmd, m_fluidNormal.Get(), m_fluidNormalState, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+
+    auto backBuffer = g_Engine->CurrentBackBufferView();
+    auto defaultDSV = g_Engine->DepthStencilView();
+    cmd->OMSetRenderTargets(1, &backBuffer, FALSE, &defaultDSV);
+
+    D3D12_VIEWPORT viewport{ 0.0f, 0.0f, static_cast<float>(g_Engine->FrameBufferWidth()), static_cast<float>(g_Engine->FrameBufferHeight()), 0.0f, 1.0f };
+    D3D12_RECT scissor{ 0, 0, static_cast<LONG>(g_Engine->FrameBufferWidth()), static_cast<LONG>(g_Engine->FrameBufferHeight()) };
+    cmd->RSSetViewports(1, &viewport);
+    cmd->RSSetScissorRects(1, &scissor);
+
+    cmd->SetGraphicsRootSignature(m_compositeRS.Get());
+    cmd->SetPipelineState(m_compositePSO.Get());
+    cmd->SetGraphicsRootConstantBufferView(0, m_cameraCB->GetAddress());
+    cmd->SetGraphicsRootDescriptorTable(1, GpuHandle(3));
+    cmd->SetGraphicsRootDescriptorTable(2, GpuHandle(4));
+    cmd->SetGraphicsRootDescriptorTable(3, GpuHandle(5));
+    cmd->SetGraphicsRootDescriptorTable(4, GpuHandle(6));
+    cmd->SetGraphicsRootDescriptorTable(5, GpuHandle(7));
+    cmd->SetGraphicsRootDescriptorTable(6, GpuHandle(8));
+    cmd->SetGraphicsRootDescriptorTable(7, m_samplerHeap->GetGPUDescriptorHandleForHeapStart());
+
+    cmd->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+    cmd->DrawInstanced(3, 1, 0, 0);
+}
+
+D3D12_GPU_DESCRIPTOR_HANDLE FluidWaterRenderer::GpuHandle(UINT index) const
+{
+    D3D12_GPU_DESCRIPTOR_HANDLE handle = m_srvUavGpuStart;
+    handle.ptr += static_cast<UINT64>(index) * m_srvUavIncrement;
+    return handle;
+}
+
+D3D12_CPU_DESCRIPTOR_HANDLE FluidWaterRenderer::CpuHandle(UINT index) const
+{
+    D3D12_CPU_DESCRIPTOR_HANDLE handle = m_srvUavCpuStart;
+    handle.ptr += static_cast<UINT64>(index) * m_srvUavIncrement;
+    return handle;
+}
+
+void FluidWaterRenderer::UpdateSSRColorSRV(ID3D12Resource* resource)
+{
+    if (!resource)
+    {
+        return;
+    }
+
+    D3D12_SHADER_RESOURCE_VIEW_DESC desc{};
+    desc.Format = DXGI_FORMAT_R11G11B10_FLOAT;
+    desc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+    desc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+    desc.Texture2D.MipLevels = 1;
+    m_device->CreateShaderResourceView(resource, &desc, CpuHandle(8));
+}
+
+void FluidWaterRenderer::CreateHeaps(ID3D12Device* device)
+{
+    // CBV/SRV/UAVヒープ（32スロット）
+    D3D12_DESCRIPTOR_HEAP_DESC heapDesc{};
+    heapDesc.NumDescriptors = 32;
+    heapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+    heapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+    device->CreateDescriptorHeap(&heapDesc, IID_PPV_ARGS(m_srvUavHeap.ReleaseAndGetAddressOf()));
+    m_srvUavIncrement = device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+    m_srvUavCpuStart = m_srvUavHeap->GetCPUDescriptorHandleForHeapStart();
+    m_srvUavGpuStart = m_srvUavHeap->GetGPUDescriptorHandleForHeapStart();
+
+    // サンプラーヒープ（1スロット）
+    D3D12_DESCRIPTOR_HEAP_DESC samplerDesc{};
+    samplerDesc.NumDescriptors = 1;
+    samplerDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER;
+    samplerDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+    device->CreateDescriptorHeap(&samplerDesc, IID_PPV_ARGS(m_samplerHeap.ReleaseAndGetAddressOf()));
+
+    // RTVヒープ（シーンカラー + 厚み + 深度）
+    D3D12_DESCRIPTOR_HEAP_DESC rtvDesc{};
+    rtvDesc.NumDescriptors = 3;
+    rtvDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+    device->CreateDescriptorHeap(&rtvDesc, IID_PPV_ARGS(m_rtvHeap.ReleaseAndGetAddressOf()));
+    m_rtvIncrement = device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+
+    // DSVヒープ（シーン深度 / FluidDS）
+    D3D12_DESCRIPTOR_HEAP_DESC dsvDesc{};
+    dsvDesc.NumDescriptors = 2;
+    dsvDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
+    device->CreateDescriptorHeap(&dsvDesc, IID_PPV_ARGS(m_dsvHeap.ReleaseAndGetAddressOf()));
+    m_dsvIncrement = device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_DSV);
+
+    m_sceneColorRTV = m_rtvHeap->GetCPUDescriptorHandleForHeapStart();
+    m_fluidThicknessRTV = { m_sceneColorRTV.ptr + m_rtvIncrement };
+    m_fluidDepthRTV = { m_fluidThicknessRTV.ptr + m_rtvIncrement };
+
+    m_sceneDepthDSV = m_dsvHeap->GetCPUDescriptorHandleForHeapStart();
+    m_fluidDSV = { m_sceneDepthDSV.ptr + m_dsvIncrement };
+}
+
+void FluidWaterRenderer::CreateConstantBuffers(ID3D12Device* device)
+{
+    m_cameraCB = std::make_unique<ConstantBuffer>(sizeof(FluidCameraConstants));
+    m_fluidCB = std::make_unique<ConstantBuffer>(sizeof(FluidParamConstants));
+
+    auto cameraView = m_cameraCB->ViewDesc();
+    auto fluidView = m_fluidCB->ViewDesc();
+    device->CreateConstantBufferView(&cameraView, CpuHandle(0));
+    device->CreateConstantBufferView(&fluidView, CpuHandle(1));
+}
+
+void FluidWaterRenderer::CreateRenderTargets(ID3D12Device* device)
+{
+    UINT width = std::max<UINT>(1u, m_width / m_downsample);
+    UINT height = std::max<UINT>(1u, m_height / m_downsample);
+
+    CD3DX12_HEAP_PROPERTIES defaultHeap(D3D12_HEAP_TYPE_DEFAULT);
+
+    // シーンカラー
+    CD3DX12_RESOURCE_DESC sceneColorDesc = CD3DX12_RESOURCE_DESC::Tex2D(
+        DXGI_FORMAT_R16G16B16A16_FLOAT, width, height, 1, 1, 1, 0,
+        D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET);
+    D3D12_CLEAR_VALUE sceneClear{};
+    sceneClear.Format = DXGI_FORMAT_R16G16B16A16_FLOAT;
+    sceneClear.Color[0] = 0;
+    sceneClear.Color[1] = 0;
+    sceneClear.Color[2] = 0;
+    sceneClear.Color[3] = 1;
+    device->CreateCommittedResource(&defaultHeap, D3D12_HEAP_FLAG_NONE, &sceneColorDesc,
+        D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, &sceneClear,
+        IID_PPV_ARGS(m_sceneColor.ReleaseAndGetAddressOf()));
+    m_sceneColorState = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+    device->CreateRenderTargetView(m_sceneColor.Get(), nullptr, m_sceneColorRTV);
+
+    D3D12_SHADER_RESOURCE_VIEW_DESC sceneColorSrv{};
+    sceneColorSrv.Format = DXGI_FORMAT_R16G16B16A16_FLOAT;
+    sceneColorSrv.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+    sceneColorSrv.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+    sceneColorSrv.Texture2D.MipLevels = 1;
+    device->CreateShaderResourceView(m_sceneColor.Get(), &sceneColorSrv, CpuHandle(3));
+
+    // シーン深度（TypelessでDSV/SRV併用）
+    CD3DX12_RESOURCE_DESC depthDesc = CD3DX12_RESOURCE_DESC::Tex2D(
+        DXGI_FORMAT_R32_TYPELESS, width, height, 1, 1, 1, 0,
+        D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL);
+    D3D12_CLEAR_VALUE depthClear{};
+    depthClear.Format = DXGI_FORMAT_D32_FLOAT;
+    depthClear.DepthStencil.Depth = 1.0f;
+    depthClear.DepthStencil.Stencil = 0;
+    device->CreateCommittedResource(&defaultHeap, D3D12_HEAP_FLAG_NONE, &depthDesc,
+        D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, &depthClear,
+        IID_PPV_ARGS(m_sceneDepthBuffer.ReleaseAndGetAddressOf()));
+    m_sceneDepthState = D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
+
+    D3D12_DEPTH_STENCIL_VIEW_DESC dsvDesc{};
+    dsvDesc.Format = DXGI_FORMAT_D32_FLOAT;
+    dsvDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
+    device->CreateDepthStencilView(m_sceneDepthBuffer.Get(), &dsvDesc, m_sceneDepthDSV);
+
+    D3D12_SHADER_RESOURCE_VIEW_DESC depthSrv{};
+    depthSrv.Format = DXGI_FORMAT_R32_FLOAT;
+    depthSrv.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+    depthSrv.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+    depthSrv.Texture2D.MipLevels = 1;
+    device->CreateShaderResourceView(m_sceneDepthBuffer.Get(), &depthSrv, CpuHandle(4));
+
+    // Fluid厚み（R16_FLOAT）
+    CD3DX12_RESOURCE_DESC thickDesc = CD3DX12_RESOURCE_DESC::Tex2D(
+        DXGI_FORMAT_R16_TYPELESS, width, height, 1, 1, 1, 0,
+        D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET | D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
+    D3D12_CLEAR_VALUE thickClear{};
+    thickClear.Format = DXGI_FORMAT_R16_FLOAT;
+    thickClear.Color[0] = 0;
+    device->CreateCommittedResource(&defaultHeap, D3D12_HEAP_FLAG_NONE, &thickDesc,
+        D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, &thickClear,
+        IID_PPV_ARGS(m_fluidThickness.ReleaseAndGetAddressOf()));
+    m_fluidThicknessState = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+
+    D3D12_RENDER_TARGET_VIEW_DESC thickRTV{};
+    thickRTV.Format = DXGI_FORMAT_R16_FLOAT;
+    thickRTV.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE2D;
+    device->CreateRenderTargetView(m_fluidThickness.Get(), &thickRTV, m_fluidThicknessRTV);
+
+    D3D12_SHADER_RESOURCE_VIEW_DESC thickSrv{};
+    thickSrv.Format = DXGI_FORMAT_R16_FLOAT;
+    thickSrv.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+    thickSrv.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+    thickSrv.Texture2D.MipLevels = 1;
+    device->CreateShaderResourceView(m_fluidThickness.Get(), &thickSrv, CpuHandle(6));
+
+    D3D12_UNORDERED_ACCESS_VIEW_DESC thickUav{};
+    thickUav.Format = DXGI_FORMAT_R16_FLOAT;
+    thickUav.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE2D;
+    device->CreateUnorderedAccessView(m_fluidThickness.Get(), nullptr, &thickUav, CpuHandle(10));
+
+    // Fluid深度（R32_FLOAT）
+    CD3DX12_RESOURCE_DESC depthLinearDesc = CD3DX12_RESOURCE_DESC::Tex2D(
+        DXGI_FORMAT_R32_TYPELESS, width, height, 1, 1, 1, 0,
+        D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET | D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
+    D3D12_CLEAR_VALUE depthLinearClear{};
+    depthLinearClear.Format = DXGI_FORMAT_R32_FLOAT;
+    depthLinearClear.Color[0] = 1.0f;
+    device->CreateCommittedResource(&defaultHeap, D3D12_HEAP_FLAG_NONE, &depthLinearDesc,
+        D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, &depthLinearClear,
+        IID_PPV_ARGS(m_fluidDepth.ReleaseAndGetAddressOf()));
+    m_fluidDepthState = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+
+    D3D12_RENDER_TARGET_VIEW_DESC depthLinearRTV{};
+    depthLinearRTV.Format = DXGI_FORMAT_R32_FLOAT;
+    depthLinearRTV.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE2D;
+    device->CreateRenderTargetView(m_fluidDepth.Get(), &depthLinearRTV, m_fluidDepthRTV);
+
+    D3D12_SHADER_RESOURCE_VIEW_DESC depthLinearSrv{};
+    depthLinearSrv.Format = DXGI_FORMAT_R32_FLOAT;
+    depthLinearSrv.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+    depthLinearSrv.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+    depthLinearSrv.Texture2D.MipLevels = 1;
+    device->CreateShaderResourceView(m_fluidDepth.Get(), &depthLinearSrv, CpuHandle(5));
+
+    D3D12_UNORDERED_ACCESS_VIEW_DESC depthLinearUav{};
+    depthLinearUav.Format = DXGI_FORMAT_R32_FLOAT;
+    depthLinearUav.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE2D;
+    device->CreateUnorderedAccessView(m_fluidDepth.Get(), nullptr, &depthLinearUav, CpuHandle(9));
+
+    // Blur用の中間バッファ
+    device->CreateCommittedResource(&defaultHeap, D3D12_HEAP_FLAG_NONE, &depthLinearDesc,
+        D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, &depthLinearClear,
+        IID_PPV_ARGS(m_fluidDepthBlur.ReleaseAndGetAddressOf()));
+    m_fluidDepthBlurState = D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
+
+    // Fluid法線（R11G11B10_FLOAT）
+    CD3DX12_RESOURCE_DESC normalDesc = CD3DX12_RESOURCE_DESC::Tex2D(
+        DXGI_FORMAT_R11G11B10_FLOAT, width, height, 1, 1, 1, 0,
+        D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
+    device->CreateCommittedResource(&defaultHeap, D3D12_HEAP_FLAG_NONE, &normalDesc,
+        D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, nullptr,
+        IID_PPV_ARGS(m_fluidNormal.ReleaseAndGetAddressOf()));
+    m_fluidNormalState = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+
+    D3D12_SHADER_RESOURCE_VIEW_DESC normalSrv{};
+    normalSrv.Format = DXGI_FORMAT_R11G11B10_FLOAT;
+    normalSrv.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+    normalSrv.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+    normalSrv.Texture2D.MipLevels = 1;
+    device->CreateShaderResourceView(m_fluidNormal.Get(), &normalSrv, CpuHandle(7));
+
+    D3D12_UNORDERED_ACCESS_VIEW_DESC normalUav{};
+    normalUav.Format = DXGI_FORMAT_R11G11B10_FLOAT;
+    normalUav.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE2D;
+    device->CreateUnorderedAccessView(m_fluidNormal.Get(), nullptr, &normalUav, CpuHandle(12));
+
+    // Fluid用DSV
+    D3D12_RESOURCE_DESC fluidDSDesc = depthDesc;
+    fluidDSDesc.Format = DXGI_FORMAT_R24G8_TYPELESS;
+    D3D12_CLEAR_VALUE fluidClear{};
+    fluidClear.Format = DXGI_FORMAT_D24_UNORM_S8_UINT;
+    fluidClear.DepthStencil.Depth = 1.0f;
+    fluidClear.DepthStencil.Stencil = 0;
+    device->CreateCommittedResource(&defaultHeap, D3D12_HEAP_FLAG_NONE, &fluidDSDesc,
+        D3D12_RESOURCE_STATE_DEPTH_WRITE, &fluidClear,
+        IID_PPV_ARGS(m_fluidDepthStencil.ReleaseAndGetAddressOf()));
+    m_fluidDepthStencilState = D3D12_RESOURCE_STATE_DEPTH_WRITE;
+    D3D12_DEPTH_STENCIL_VIEW_DESC fluidDSVDesc{};
+    fluidDSVDesc.Format = DXGI_FORMAT_D24_UNORM_S8_UINT;
+    fluidDSVDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
+    device->CreateDepthStencilView(m_fluidDepthStencil.Get(), &fluidDSVDesc, m_fluidDSV);
+}
+
+void FluidWaterRenderer::CreateRootSignatures(ID3D12Device* device)
+{
+    ComPtr<ID3DBlob> blob;
+    ComPtr<ID3DBlob> error;
+
+    // DepthThickness RS
+    CD3DX12_DESCRIPTOR_RANGE depthSrvRange;
+    depthSrvRange.Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0);
+    CD3DX12_DESCRIPTOR_RANGE samplerRange;
+    samplerRange.Init(D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER, 1, 0);
+
+    CD3DX12_ROOT_PARAMETER depthParams[4];
+    depthParams[0].InitAsConstantBufferView(0);
+    depthParams[1].InitAsConstantBufferView(1);
+    depthParams[2].InitAsDescriptorTable(1, &depthSrvRange);
+    depthParams[3].InitAsDescriptorTable(1, &samplerRange);
+
+    D3D12_ROOT_SIGNATURE_DESC rsDesc{};
+    rsDesc.NumParameters = _countof(depthParams);
+    rsDesc.pParameters = depthParams;
+    rsDesc.Flags = D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT;
+    D3D12SerializeRootSignature(&rsDesc, D3D_ROOT_SIGNATURE_VERSION_1, blob.GetAddressOf(), error.GetAddressOf());
+    device->CreateRootSignature(0, blob->GetBufferPointer(), blob->GetBufferSize(), IID_PPV_ARGS(m_depthThicknessRS.ReleaseAndGetAddressOf()));
+
+    // Blur RS
+    CD3DX12_DESCRIPTOR_RANGE blurSrvRange;
+    blurSrvRange.Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0);
+    CD3DX12_DESCRIPTOR_RANGE blurUavRange;
+    blurUavRange.Init(D3D12_DESCRIPTOR_RANGE_TYPE_UAV, 1, 0);
+
+    CD3DX12_ROOT_PARAMETER blurParams[3];
+    blurParams[0].InitAsDescriptorTable(1, &blurSrvRange);
+    blurParams[1].InitAsDescriptorTable(1, &samplerRange);
+    blurParams[2].InitAsDescriptorTable(1, &blurUavRange);
+
+    rsDesc = {};
+    rsDesc.NumParameters = _countof(blurParams);
+    rsDesc.pParameters = blurParams;
+    rsDesc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
+    D3D12SerializeRootSignature(&rsDesc, D3D_ROOT_SIGNATURE_VERSION_1, blob.ReleaseAndGetAddressOf(), error.ReleaseAndGetAddressOf());
+    device->CreateRootSignature(0, blob->GetBufferPointer(), blob->GetBufferSize(), IID_PPV_ARGS(m_blurRS.ReleaseAndGetAddressOf()));
+
+    // Normal RS
+    CD3DX12_DESCRIPTOR_RANGE normalSrvRange;
+    normalSrvRange.Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0);
+    CD3DX12_DESCRIPTOR_RANGE normalUavRange;
+    normalUavRange.Init(D3D12_DESCRIPTOR_RANGE_TYPE_UAV, 1, 0);
+
+    CD3DX12_ROOT_PARAMETER normalParams[2];
+    normalParams[0].InitAsDescriptorTable(1, &normalSrvRange);
+    normalParams[1].InitAsDescriptorTable(1, &normalUavRange);
+
+    rsDesc = {};
+    rsDesc.NumParameters = _countof(normalParams);
+    rsDesc.pParameters = normalParams;
+    rsDesc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE;
+    D3D12SerializeRootSignature(&rsDesc, D3D_ROOT_SIGNATURE_VERSION_1, blob.ReleaseAndGetAddressOf(), error.ReleaseAndGetAddressOf());
+    device->CreateRootSignature(0, blob->GetBufferPointer(), blob->GetBufferSize(), IID_PPV_ARGS(m_normalRS.ReleaseAndGetAddressOf()));
+
+    // Composite RS
+    CD3DX12_DESCRIPTOR_RANGE compRange[6];
+    for (UINT i = 0; i < 6; ++i)
+    {
+        compRange[i].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, i);
+    }
+
+    CD3DX12_ROOT_PARAMETER compParams[8];
+    compParams[0].InitAsConstantBufferView(0);
+    for (int i = 0; i < 6; ++i)
+    {
+        compParams[1 + i].InitAsDescriptorTable(1, &compRange[i]);
+    }
+    compParams[7].InitAsDescriptorTable(1, &samplerRange);
+
+    rsDesc = {};
+    rsDesc.NumParameters = _countof(compParams);
+    rsDesc.pParameters = compParams;
+    rsDesc.Flags = D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT;
+    D3D12SerializeRootSignature(&rsDesc, D3D_ROOT_SIGNATURE_VERSION_1, blob.ReleaseAndGetAddressOf(), error.ReleaseAndGetAddressOf());
+    device->CreateRootSignature(0, blob->GetBufferPointer(), blob->GetBufferSize(), IID_PPV_ARGS(m_compositeRS.ReleaseAndGetAddressOf()));
+}
+
+void FluidWaterRenderer::CreatePipelineStates(ID3D12Device* device)
+{
+    ComPtr<ID3DBlob> vs;
+    ComPtr<ID3DBlob> ps;
+    ComPtr<ID3DBlob> cs;
+
+    // DepthThickness PSO
+    CompileShader(L"Shaders/Fluid/FluidDepthThicknessVS.hlsl", "VSMain", "vs_5_1", vs);
+    CompileShader(L"Shaders/Fluid/FluidDepthThicknessPS.hlsl", "PSMain", "ps_5_1", ps);
+
+    D3D12_GRAPHICS_PIPELINE_STATE_DESC desc{};
+    desc.pRootSignature = m_depthThicknessRS.Get();
+    desc.VS = { vs->GetBufferPointer(), vs->GetBufferSize() };
+    desc.PS = { ps->GetBufferPointer(), ps->GetBufferSize() };
+    desc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+    desc.BlendState.RenderTarget[0].BlendEnable = TRUE;
+    desc.BlendState.RenderTarget[0].SrcBlend = D3D12_BLEND_ONE;
+    desc.BlendState.RenderTarget[0].DestBlend = D3D12_BLEND_ONE;
+    desc.BlendState.RenderTarget[0].BlendOp = D3D12_BLEND_OP_ADD;
+    desc.SampleMask = UINT_MAX;
+    desc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+    desc.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
+    desc.DepthStencilState.DepthEnable = TRUE;
+    desc.DepthStencilState.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ALL;
+    desc.DepthStencilState.DepthFunc = D3D12_COMPARISON_FUNC_LESS_EQUAL;
+    desc.NumRenderTargets = 2;
+    desc.RTVFormats[0] = DXGI_FORMAT_R16_FLOAT;
+    desc.RTVFormats[1] = DXGI_FORMAT_R32_FLOAT;
+    desc.DSVFormat = DXGI_FORMAT_D24_UNORM_S8_UINT;
+    desc.SampleDesc.Count = 1;
+    desc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+    device->CreateGraphicsPipelineState(&desc, IID_PPV_ARGS(m_depthThicknessPSO.ReleaseAndGetAddressOf()));
+
+    // Blur X
+    CompileShader(L"Shaders/Fluid/BilateralBlurX.hlsl", "CSMain", "cs_5_1", cs);
+    D3D12_COMPUTE_PIPELINE_STATE_DESC cdesc{};
+    cdesc.pRootSignature = m_blurRS.Get();
+    cdesc.CS = { cs->GetBufferPointer(), cs->GetBufferSize() };
+    device->CreateComputePipelineState(&cdesc, IID_PPV_ARGS(m_blurXPSO.ReleaseAndGetAddressOf()));
+
+    // Blur Y
+    CompileShader(L"Shaders/Fluid/BilateralBlurY.hlsl", "CSMain", "cs_5_1", cs);
+    cdesc.CS = { cs->GetBufferPointer(), cs->GetBufferSize() };
+    device->CreateComputePipelineState(&cdesc, IID_PPV_ARGS(m_blurYPSO.ReleaseAndGetAddressOf()));
+
+    // Normal reconstruct
+    CompileShader(L"Shaders/Fluid/ReconstructNormalCS.hlsl", "CSMain", "cs_5_1", cs);
+    cdesc.pRootSignature = m_normalRS.Get();
+    cdesc.CS = { cs->GetBufferPointer(), cs->GetBufferSize() };
+    device->CreateComputePipelineState(&cdesc, IID_PPV_ARGS(m_normalPSO.ReleaseAndGetAddressOf()));
+
+    // Composite
+    CompileShader(L"FullscreenVS.hlsl", "main", "vs_5_1", vs);
+    CompileShader(L"Shaders/Fluid/CompositeWaterPS.hlsl", "PSMain", "ps_5_1", ps);
+    desc = {};
+    desc.pRootSignature = m_compositeRS.Get();
+    desc.VS = { vs->GetBufferPointer(), vs->GetBufferSize() };
+    desc.PS = { ps->GetBufferPointer(), ps->GetBufferSize() };
+    desc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+    desc.SampleMask = UINT_MAX;
+    desc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+    desc.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
+    desc.DepthStencilState.DepthEnable = FALSE;
+    desc.NumRenderTargets = 1;
+    desc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+    desc.SampleDesc.Count = 1;
+    desc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+    device->CreateGraphicsPipelineState(&desc, IID_PPV_ARGS(m_compositePSO.ReleaseAndGetAddressOf()));
+}
+
+void FluidWaterRenderer::CreateSamplers(ID3D12Device* device)
+{
+    D3D12_SAMPLER_DESC desc{};
+    desc.Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
+    desc.AddressU = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
+    desc.AddressV = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
+    desc.AddressW = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
+    desc.MaxLOD = D3D12_FLOAT32_MAX;
+    device->CreateSampler(&desc, m_samplerHeap->GetCPUDescriptorHandleForHeapStart());
+}
+
+void FluidWaterRenderer::UpdateCameraConstants(const Camera& camera)
+{
+    FluidCameraConstants* cb = m_cameraCB->GetPtr<FluidCameraConstants>();
+    XMMATRIX viewMatrix = camera.GetViewMatrix();
+    XMMATRIX projMatrix = camera.GetProjMatrix();
+    XMStoreFloat4x4(&cb->View, XMMatrixTranspose(viewMatrix));
+    XMStoreFloat4x4(&cb->Proj, XMMatrixTranspose(projMatrix));
+    cb->ScreenSize = XMFLOAT2(static_cast<float>(m_width), static_cast<float>(m_height));
+    cb->InvScreenSize = XMFLOAT2(1.0f / m_width, 1.0f / m_height);
+    cb->NearZ = camera.GetNearClip();
+    cb->FarZ = camera.GetFarClip();
+    cb->IorF0 = XMFLOAT3(0.02f, 0.02f, 0.02f);
+    cb->Absorb = 1.2f;
+    cb->Options = XMUINT4(static_cast<UINT>(m_debugView), m_ssrQuality, m_usePlanarReflection ? 1u : 0u, m_showGrid ? 1u : 0u);
+}
+
+void FluidWaterRenderer::UpdateFluidConstants(const FluidSystem& fluid)
+{
+    FluidParamConstants* cb = m_fluidCB->GetPtr<FluidParamConstants>();
+    cb->Radius = fluid.RenderParticleRadius();
+    cb->ThicknessScale = 1.0f;
+    cb->ParticleCount = fluid.ActiveParticleCount();
+    cb->Downsample = static_cast<float>(m_downsample);
+}
+
+void FluidWaterRenderer::Transition(ID3D12GraphicsCommandList* cmd, ID3D12Resource* resource, D3D12_RESOURCE_STATES& state, D3D12_RESOURCE_STATES after)
+{
+    if (!resource || state == after)
+    {
+        return;
+    }
+    auto barrier = CD3DX12_RESOURCE_BARRIER::Transition(resource, state, after);
+    cmd->ResourceBarrier(1, &barrier);
+    state = after;
+}

--- a/DirectX12/Source/Rendering/FluidWaterRenderer.h
+++ b/DirectX12/Source/Rendering/FluidWaterRenderer.h
@@ -1,0 +1,164 @@
+#pragma once
+#include <d3d12.h>
+#include <wrl/client.h>
+#include <memory>
+#include <cstdint>
+#include <DirectXMath.h>
+#include "ConstantBuffer.h"
+
+class Camera;
+class FluidSystem;
+class SSRRenderer;
+
+// ================================
+// 水レンダリング用の定数バッファ構造体
+// ================================
+struct FluidCameraConstants
+{
+    DirectX::XMFLOAT4X4 View;        // ビュー行列（転置済み）
+    DirectX::XMFLOAT4X4 Proj;        // プロジェクション行列（転置済み）
+    DirectX::XMFLOAT2   ScreenSize;  // 画面サイズ
+    DirectX::XMFLOAT2   InvScreenSize; // 逆画面サイズ
+    float NearZ;                     // ニアクリップ
+    float FarZ;                      // ファークリップ
+    DirectX::XMFLOAT3 IorF0;         // フレネルF0
+    float Absorb;                    // 吸収係数
+    DirectX::XMUINT4 Options;        // x:DebugView y:SSRQuality z:Planar(0/1) w:GridDebug(0/1)
+};
+
+struct FluidParamConstants
+{
+    float Radius;            // 粒子半径
+    float ThicknessScale;    // 厚みスケール
+    uint32_t ParticleCount;  // 粒子数
+    float Downsample;        // ダウンサンプル倍率（1/2/4）
+};
+
+enum class FluidDebugView
+{
+    Composite = 0,
+    Depth = 1,
+    Thickness = 2,
+    Normal = 3
+};
+
+class FluidWaterRenderer
+{
+public:
+    FluidWaterRenderer();
+    bool Init(ID3D12Device* device, UINT width, UINT height);
+    void Resize(UINT width, UINT height);
+    void BeginSceneRender(ID3D12GraphicsCommandList* cmd);
+    void EndSceneRender(ID3D12GraphicsCommandList* cmd);
+    void RenderDepthThickness(ID3D12GraphicsCommandList* cmd, const Camera& camera, FluidSystem& fluid);
+    void BlurAndNormal(ID3D12GraphicsCommandList* cmd);
+    void Composite(ID3D12GraphicsCommandList* cmd);
+
+    // デバッグ表示設定
+    void SetDebugView(FluidDebugView view) { m_debugView = view; }
+    void SetSSRQuality(uint32_t quality) { m_ssrQuality = quality; }
+    void TogglePlanarReflection(bool enable) { m_usePlanarReflection = enable; }
+    void SetDownsample(uint32_t step);
+    void EnableGridDebug(bool enable) { m_showGrid = enable; }
+
+    // シーンカラー／深度を外部へ提供
+    D3D12_CPU_DESCRIPTOR_HANDLE SceneColorRTV() const { return m_sceneColorRTV; }
+    D3D12_CPU_DESCRIPTOR_HANDLE SceneDepthDSV() const { return m_sceneDepthDSV; }
+    ID3D12Resource* SceneColorResource() const { return m_sceneColor.Get(); }
+    ID3D12Resource* SceneDepthResource() const { return m_sceneDepthBuffer.Get(); }
+
+    // SRV／UAVヒープ取得
+    ID3D12DescriptorHeap* DescriptorHeap() const { return m_srvUavHeap.Get(); }
+    ID3D12DescriptorHeap* SamplerHeap() const { return m_samplerHeap.Get(); }
+    D3D12_GPU_DESCRIPTOR_HANDLE GpuHandle(UINT index) const;
+    D3D12_CPU_DESCRIPTOR_HANDLE CpuHandle(UINT index) const;
+
+    // 各種テクスチャを他モジュールへ
+    ID3D12Resource* FluidDepthTexture() const { return m_fluidDepth.Get(); }
+    ID3D12Resource* FluidNormalTexture() const { return m_fluidNormal.Get(); }
+    uint32_t SSRQuality() const { return m_ssrQuality; }
+
+    // SSRからのカラーをSRVとして登録するためのヘルパ
+    void UpdateSSRColorSRV(ID3D12Resource* resource);
+
+    // 現在の解像度取得
+    UINT Width() const { return m_width; }
+    UINT Height() const { return m_height; }
+
+private:
+    void CreateHeaps(ID3D12Device* device);
+    void CreateConstantBuffers(ID3D12Device* device);
+    void CreateRenderTargets(ID3D12Device* device);
+    void CreateRootSignatures(ID3D12Device* device);
+    void CreatePipelineStates(ID3D12Device* device);
+    void CreateSamplers(ID3D12Device* device);
+
+    void UpdateCameraConstants(const Camera& camera);
+    void UpdateFluidConstants(const FluidSystem& fluid);
+
+    void Transition(ID3D12GraphicsCommandList* cmd, ID3D12Resource* resource, D3D12_RESOURCE_STATES& state, D3D12_RESOURCE_STATES after);
+
+private:
+    bool m_initialized = false;
+    ID3D12Device* m_device = nullptr;
+    UINT m_width = 0;
+    UINT m_height = 0;
+    uint32_t m_downsample = 1;
+
+    // ディスクリプタヒープ
+    Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> m_srvUavHeap;
+    Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> m_samplerHeap;
+    Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
+    Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> m_dsvHeap;
+    UINT m_srvUavIncrement = 0;
+    UINT m_rtvIncrement = 0;
+    UINT m_dsvIncrement = 0;
+
+    D3D12_CPU_DESCRIPTOR_HANDLE m_sceneColorRTV{};
+    D3D12_CPU_DESCRIPTOR_HANDLE m_fluidThicknessRTV{};
+    D3D12_CPU_DESCRIPTOR_HANDLE m_fluidDepthRTV{};
+    D3D12_CPU_DESCRIPTOR_HANDLE m_sceneDepthDSV{};
+    D3D12_CPU_DESCRIPTOR_HANDLE m_fluidDSV{};
+
+    D3D12_GPU_DESCRIPTOR_HANDLE m_srvUavGpuStart{};
+    D3D12_CPU_DESCRIPTOR_HANDLE m_srvUavCpuStart{};
+
+    // 定数バッファ
+    std::unique_ptr<ConstantBuffer> m_cameraCB;
+    std::unique_ptr<ConstantBuffer> m_fluidCB;
+
+    // テクスチャリソース
+    Microsoft::WRL::ComPtr<ID3D12Resource> m_sceneColor;
+    Microsoft::WRL::ComPtr<ID3D12Resource> m_sceneDepthBuffer; // typeless depth
+    Microsoft::WRL::ComPtr<ID3D12Resource> m_fluidDepth;
+    Microsoft::WRL::ComPtr<ID3D12Resource> m_fluidThickness;
+    Microsoft::WRL::ComPtr<ID3D12Resource> m_fluidDepthBlur;
+    Microsoft::WRL::ComPtr<ID3D12Resource> m_fluidNormal;
+    Microsoft::WRL::ComPtr<ID3D12Resource> m_fluidDepthStencil;
+
+    D3D12_RESOURCE_STATES m_sceneColorState = D3D12_RESOURCE_STATE_COMMON;
+    D3D12_RESOURCE_STATES m_sceneDepthState = D3D12_RESOURCE_STATE_COMMON;
+    D3D12_RESOURCE_STATES m_fluidDepthState = D3D12_RESOURCE_STATE_COMMON;
+    D3D12_RESOURCE_STATES m_fluidThicknessState = D3D12_RESOURCE_STATE_COMMON;
+    D3D12_RESOURCE_STATES m_fluidDepthBlurState = D3D12_RESOURCE_STATE_COMMON;
+    D3D12_RESOURCE_STATES m_fluidNormalState = D3D12_RESOURCE_STATE_COMMON;
+    D3D12_RESOURCE_STATES m_fluidDepthStencilState = D3D12_RESOURCE_STATE_DEPTH_WRITE;
+
+    // ルートシグネチャ / PSO
+    Microsoft::WRL::ComPtr<ID3D12RootSignature> m_depthThicknessRS;
+    Microsoft::WRL::ComPtr<ID3D12RootSignature> m_blurRS;
+    Microsoft::WRL::ComPtr<ID3D12RootSignature> m_normalRS;
+    Microsoft::WRL::ComPtr<ID3D12RootSignature> m_compositeRS;
+
+    Microsoft::WRL::ComPtr<ID3D12PipelineState> m_depthThicknessPSO;
+    Microsoft::WRL::ComPtr<ID3D12PipelineState> m_blurXPSO;
+    Microsoft::WRL::ComPtr<ID3D12PipelineState> m_blurYPSO;
+    Microsoft::WRL::ComPtr<ID3D12PipelineState> m_normalPSO;
+    Microsoft::WRL::ComPtr<ID3D12PipelineState> m_compositePSO;
+
+    // デバッグ / 設定
+    FluidDebugView m_debugView = FluidDebugView::Composite;
+    uint32_t m_ssrQuality = 1;
+    bool m_usePlanarReflection = false;
+    bool m_showGrid = false;
+};

--- a/DirectX12/Source/Rendering/SSRRenderer.cpp
+++ b/DirectX12/Source/Rendering/SSRRenderer.cpp
@@ -1,0 +1,178 @@
+#include "SSRRenderer.h"
+#include "Camera.h"
+#include "Engine.h"
+#include <d3dx12.h>
+#include <d3dcompiler.h>
+
+#pragma comment(lib, "d3dcompiler.lib")
+
+using Microsoft::WRL::ComPtr;
+using namespace DirectX;
+
+SSRRenderer::SSRRenderer() = default;
+
+bool SSRRenderer::Init(ID3D12Device* device, FluidWaterRenderer& fluid, UINT width, UINT height)
+{
+    if (!device)
+    {
+        return false;
+    }
+    m_device = device;
+    m_cameraCB = std::make_unique<ConstantBuffer>(sizeof(FluidCameraConstants));
+    m_width = width;
+    m_height = height;
+
+    CreatePipeline(device);
+    CreateTarget(device, fluid, width, height);
+    return true;
+}
+
+void SSRRenderer::Resize(FluidWaterRenderer& fluid, UINT width, UINT height)
+{
+    if (!m_device || (width == m_width && height == m_height))
+    {
+        return;
+    }
+    m_width = width;
+    m_height = height;
+    CreateTarget(m_device, fluid, width, height);
+}
+
+void SSRRenderer::RenderSSR(ID3D12GraphicsCommandList* cmd, FluidWaterRenderer& fluid, const Camera& camera)
+{
+    if (!cmd || !m_ssrTexture)
+    {
+        return;
+    }
+
+    UpdateCameraCB(camera, fluid.SSRQuality());
+    Transition(cmd, D3D12_RESOURCE_STATE_RENDER_TARGET);
+
+    cmd->OMSetRenderTargets(1, &m_ssrRTV, FALSE, nullptr);
+    float clearColor[4] = { 0,0,0,0 };
+    cmd->ClearRenderTargetView(m_ssrRTV, clearColor, 0, nullptr);
+
+    D3D12_VIEWPORT viewport{ 0.0f, 0.0f, static_cast<float>(m_width), static_cast<float>(m_height), 0.0f, 1.0f };
+    D3D12_RECT scissor{ 0, 0, static_cast<LONG>(m_width), static_cast<LONG>(m_height) };
+    cmd->RSSetViewports(1, &viewport);
+    cmd->RSSetScissorRects(1, &scissor);
+
+    ID3D12DescriptorHeap* heaps[] = { fluid.DescriptorHeap(), fluid.SamplerHeap() };
+    cmd->SetDescriptorHeaps(2, heaps);
+
+    cmd->SetGraphicsRootSignature(m_rootSignature.Get());
+    cmd->SetPipelineState(m_pipelineState.Get());
+    cmd->SetGraphicsRootConstantBufferView(0, m_cameraCB->GetAddress());
+    cmd->SetGraphicsRootDescriptorTable(1, fluid.GpuHandle(3));
+    cmd->SetGraphicsRootDescriptorTable(2, fluid.GpuHandle(4));
+    cmd->SetGraphicsRootDescriptorTable(3, fluid.GpuHandle(7));
+    cmd->SetGraphicsRootDescriptorTable(4, fluid.SamplerHeap()->GetGPUDescriptorHandleForHeapStart());
+
+    cmd->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+    cmd->DrawInstanced(3, 1, 0, 0);
+
+    Transition(cmd, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+}
+
+void SSRRenderer::CreateTarget(ID3D12Device* device, FluidWaterRenderer& fluid, UINT width, UINT height)
+{
+    CD3DX12_DESCRIPTOR_HEAP_DESC rtvDesc(D3D12_DESCRIPTOR_HEAP_TYPE_RTV, 1);
+    device->CreateDescriptorHeap(&rtvDesc, IID_PPV_ARGS(m_rtvHeap.ReleaseAndGetAddressOf()));
+    m_ssrRTV = m_rtvHeap->GetCPUDescriptorHandleForHeapStart();
+
+    CD3DX12_RESOURCE_DESC desc = CD3DX12_RESOURCE_DESC::Tex2D(
+        DXGI_FORMAT_R11G11B10_FLOAT, width, height, 1, 1, 1, 0,
+        D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET);
+    D3D12_CLEAR_VALUE clear{};
+    clear.Format = DXGI_FORMAT_R11G11B10_FLOAT;
+    clear.Color[0] = clear.Color[1] = clear.Color[2] = 0.0f;
+    clear.Color[3] = 1.0f;
+    CD3DX12_HEAP_PROPERTIES heap(D3D12_HEAP_TYPE_DEFAULT);
+    device->CreateCommittedResource(&heap, D3D12_HEAP_FLAG_NONE, &desc,
+        D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, &clear,
+        IID_PPV_ARGS(m_ssrTexture.ReleaseAndGetAddressOf()));
+    m_ssrState = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+
+    device->CreateRenderTargetView(m_ssrTexture.Get(), nullptr, m_ssrRTV);
+    fluid.UpdateSSRColorSRV(m_ssrTexture.Get());
+}
+
+void SSRRenderer::CreatePipeline(ID3D12Device* device)
+{
+    if (!m_rootSignature)
+    {
+        CD3DX12_DESCRIPTOR_RANGE ranges[3];
+        ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0); // SceneColor
+        ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 1); // SceneDepth
+        ranges[2].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 2); // Normal
+
+        CD3DX12_DESCRIPTOR_RANGE samplerRange;
+        samplerRange.Init(D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER, 1, 0);
+
+        CD3DX12_ROOT_PARAMETER params[5];
+        params[0].InitAsConstantBufferView(0);
+        params[1].InitAsDescriptorTable(1, &ranges[0]);
+        params[2].InitAsDescriptorTable(1, &ranges[1]);
+        params[3].InitAsDescriptorTable(1, &ranges[2]);
+        params[4].InitAsDescriptorTable(1, &samplerRange);
+
+        D3D12_ROOT_SIGNATURE_DESC desc{};
+        desc.NumParameters = _countof(params);
+        desc.pParameters = params;
+        desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT;
+
+        ComPtr<ID3DBlob> blob;
+        ComPtr<ID3DBlob> error;
+        D3D12SerializeRootSignature(&desc, D3D_ROOT_SIGNATURE_VERSION_1, blob.GetAddressOf(), error.GetAddressOf());
+        device->CreateRootSignature(0, blob->GetBufferPointer(), blob->GetBufferSize(), IID_PPV_ARGS(m_rootSignature.ReleaseAndGetAddressOf()));
+    }
+
+    ComPtr<ID3DBlob> vs;
+    ComPtr<ID3DBlob> ps;
+    D3DCompileFromFile(L"FullscreenVS.hlsl", nullptr, D3D_COMPILE_STANDARD_FILE_INCLUDE,
+        "main", "vs_5_1", 0, 0, vs.GetAddressOf(), nullptr);
+    D3DCompileFromFile(L"Shaders/SSR/SSR_PS.hlsl", nullptr, D3D_COMPILE_STANDARD_FILE_INCLUDE,
+        "PSMain", "ps_5_1", 0, 0, ps.GetAddressOf(), nullptr);
+
+    D3D12_GRAPHICS_PIPELINE_STATE_DESC pso{};
+    pso.pRootSignature = m_rootSignature.Get();
+    pso.VS = { vs->GetBufferPointer(), vs->GetBufferSize() };
+    pso.PS = { ps->GetBufferPointer(), ps->GetBufferSize() };
+    pso.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+    pso.SampleMask = UINT_MAX;
+    pso.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+    pso.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
+    pso.DepthStencilState.DepthEnable = FALSE;
+    pso.NumRenderTargets = 1;
+    pso.RTVFormats[0] = DXGI_FORMAT_R11G11B10_FLOAT;
+    pso.SampleDesc.Count = 1;
+    pso.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+    device->CreateGraphicsPipelineState(&pso, IID_PPV_ARGS(m_pipelineState.ReleaseAndGetAddressOf()));
+}
+
+void SSRRenderer::UpdateCameraCB(const Camera& camera, UINT ssrQuality)
+{
+    FluidCameraConstants* cb = m_cameraCB->GetPtr<FluidCameraConstants>();
+    XMMATRIX viewMatrix = camera.GetViewMatrix();
+    XMMATRIX projMatrix = camera.GetProjMatrix();
+    XMStoreFloat4x4(&cb->View, XMMatrixTranspose(viewMatrix));
+    XMStoreFloat4x4(&cb->Proj, XMMatrixTranspose(projMatrix));
+    cb->ScreenSize = XMFLOAT2(static_cast<float>(m_width), static_cast<float>(m_height));
+    cb->InvScreenSize = XMFLOAT2(1.0f / m_width, 1.0f / m_height);
+    cb->NearZ = camera.GetNearClip();
+    cb->FarZ = camera.GetFarClip();
+    cb->IorF0 = XMFLOAT3(0.02f, 0.02f, 0.02f);
+    cb->Absorb = 1.2f;
+    cb->Options = XMUINT4(0, ssrQuality, 0, 0);
+}
+
+void SSRRenderer::Transition(ID3D12GraphicsCommandList* cmd, D3D12_RESOURCE_STATES after)
+{
+    if (!m_ssrTexture || m_ssrState == after)
+    {
+        return;
+    }
+    auto barrier = CD3DX12_RESOURCE_BARRIER::Transition(m_ssrTexture.Get(), m_ssrState, after);
+    cmd->ResourceBarrier(1, &barrier);
+    m_ssrState = after;
+}

--- a/DirectX12/Source/Rendering/SSRRenderer.h
+++ b/DirectX12/Source/Rendering/SSRRenderer.h
@@ -1,0 +1,39 @@
+#pragma once
+#include <d3d12.h>
+#include <wrl/client.h>
+#include <memory>
+#include <DirectXMath.h>
+#include "ConstantBuffer.h"
+#include "FluidWaterRenderer.h"
+
+class Camera;
+
+class SSRRenderer
+{
+public:
+    SSRRenderer();
+    bool Init(ID3D12Device* device, FluidWaterRenderer& fluid, UINT width, UINT height);
+    void Resize(FluidWaterRenderer& fluid, UINT width, UINT height);
+    void RenderSSR(ID3D12GraphicsCommandList* cmd, FluidWaterRenderer& fluid, const Camera& camera);
+
+    ID3D12Resource* SSRTexture() const { return m_ssrTexture.Get(); }
+
+private:
+    void CreateTarget(ID3D12Device* device, FluidWaterRenderer& fluid, UINT width, UINT height);
+    void CreatePipeline(ID3D12Device* device);
+    void UpdateCameraCB(const Camera& camera, UINT ssrQuality);
+    void Transition(ID3D12GraphicsCommandList* cmd, D3D12_RESOURCE_STATES after);
+
+private:
+    ID3D12Device* m_device = nullptr;
+    UINT m_width = 0;
+    UINT m_height = 0;
+
+    Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> m_rtvHeap;
+    Microsoft::WRL::ComPtr<ID3D12Resource> m_ssrTexture;
+    Microsoft::WRL::ComPtr<ID3D12RootSignature> m_rootSignature;
+    Microsoft::WRL::ComPtr<ID3D12PipelineState> m_pipelineState;
+    std::unique_ptr<ConstantBuffer> m_cameraCB;
+    D3D12_CPU_DESCRIPTOR_HANDLE m_ssrRTV{};
+    D3D12_RESOURCE_STATES m_ssrState = D3D12_RESOURCE_STATE_COMMON;
+};


### PR DESCRIPTION
## Summary
- track the camera's near/far clip planes with new accessors so the water and SSR passes can consume consistent depth ranges
- fix the fluid water renderer's constant-buffer view creation while managing resource transitions and viewports for the downsampled targets
- update the SSR renderer to set its viewport to the reflection target size and rely on the shared camera constants

## Testing
- Not run (environment lacks DirectX build tooling)


------
https://chatgpt.com/codex/tasks/task_e_68d9d613b39083328b7aeead37e180f0