### PR TITLE
Add local d3dx12 helper header

### DIFF
--- a/DirectX12/d3dx12.h
+++ b/DirectX12/d3dx12.h
@@ -1,0 +1,470 @@
+#pragma once
+
+// このヘッダは DirectX 12 のサンプルで利用されるユーティリティクラス群を最小構成で再定義しています。
+// プロジェクト内で <d3dx12.h> をインクルードできるようにし、主要なヘルパーだけを提供します。
+
+#include <d3d12.h>
+#include <cstdint>
+
+struct CD3DX12_DEFAULT {};
+
+struct CD3DX12_HEAP_PROPERTIES : public D3D12_HEAP_PROPERTIES
+{
+    CD3DX12_HEAP_PROPERTIES()
+    {
+        Type = D3D12_HEAP_TYPE_CUSTOM;
+        CPUPageProperty = D3D12_CPU_PAGE_PROPERTY_UNKNOWN;
+        MemoryPoolPreference = D3D12_MEMORY_POOL_UNKNOWN;
+        CreationNodeMask = 1;
+        VisibleNodeMask = 1;
+    }
+
+    explicit CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE type, UINT creationNodeMask = 1, UINT visibleNodeMask = 1)
+    {
+        Type = type;
+        CPUPageProperty = D3D12_CPU_PAGE_PROPERTY_UNKNOWN;
+        MemoryPoolPreference = D3D12_MEMORY_POOL_UNKNOWN;
+        CreationNodeMask = creationNodeMask;
+        VisibleNodeMask = visibleNodeMask;
+    }
+
+    CD3DX12_HEAP_PROPERTIES(
+        D3D12_CPU_PAGE_PROPERTY cpuPageProperty,
+        D3D12_MEMORY_POOL memoryPoolPreference,
+        UINT creationNodeMask = 1,
+        UINT visibleNodeMask = 1)
+    {
+        Type = D3D12_HEAP_TYPE_CUSTOM;
+        CPUPageProperty = cpuPageProperty;
+        MemoryPoolPreference = memoryPoolPreference;
+        CreationNodeMask = creationNodeMask;
+        VisibleNodeMask = visibleNodeMask;
+    }
+};
+
+struct CD3DX12_RESOURCE_DESC : public D3D12_RESOURCE_DESC
+{
+    CD3DX12_RESOURCE_DESC()
+    {
+        Dimension = D3D12_RESOURCE_DIMENSION_UNKNOWN;
+        Alignment = 0;
+        Width = 0;
+        Height = 0;
+        DepthOrArraySize = 0;
+        MipLevels = 0;
+        Format = DXGI_FORMAT_UNKNOWN;
+        SampleDesc.Count = 1;
+        SampleDesc.Quality = 0;
+        Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
+        Flags = D3D12_RESOURCE_FLAG_NONE;
+    }
+
+    CD3DX12_RESOURCE_DESC(
+        D3D12_RESOURCE_DIMENSION dimension,
+        UINT64 alignment,
+        UINT64 width,
+        UINT height,
+        UINT16 depthOrArraySize,
+        UINT16 mipLevels,
+        DXGI_FORMAT format,
+        UINT sampleCount,
+        UINT sampleQuality,
+        D3D12_TEXTURE_LAYOUT layout,
+        D3D12_RESOURCE_FLAGS flags)
+    {
+        Dimension = dimension;
+        Alignment = alignment;
+        Width = width;
+        Height = height;
+        DepthOrArraySize = depthOrArraySize;
+        MipLevels = mipLevels;
+        Format = format;
+        SampleDesc.Count = sampleCount;
+        SampleDesc.Quality = sampleQuality;
+        Layout = layout;
+        Flags = flags;
+    }
+
+    static inline CD3DX12_RESOURCE_DESC Buffer(
+        UINT64 width,
+        D3D12_RESOURCE_FLAGS flags = D3D12_RESOURCE_FLAG_NONE,
+        UINT64 alignment = 0)
+    {
+        return CD3DX12_RESOURCE_DESC(
+            D3D12_RESOURCE_DIMENSION_BUFFER,
+            alignment,
+            width,
+            1,
+            1,
+            1,
+            DXGI_FORMAT_UNKNOWN,
+            1,
+            0,
+            D3D12_TEXTURE_LAYOUT_ROW_MAJOR,
+            flags);
+    }
+
+    static inline CD3DX12_RESOURCE_DESC Tex2D(
+        DXGI_FORMAT format,
+        UINT64 width,
+        UINT height,
+        UINT16 arraySize = 1,
+        UINT16 mipLevels = 0,
+        UINT sampleCount = 1,
+        UINT sampleQuality = 0,
+        D3D12_RESOURCE_FLAGS flags = D3D12_RESOURCE_FLAG_NONE,
+        D3D12_TEXTURE_LAYOUT layout = D3D12_TEXTURE_LAYOUT_UNKNOWN,
+        UINT64 alignment = 0)
+    {
+        return CD3DX12_RESOURCE_DESC(
+            D3D12_RESOURCE_DIMENSION_TEXTURE2D,
+            alignment,
+            width,
+            height,
+            arraySize,
+            mipLevels,
+            format,
+            sampleCount,
+            sampleQuality,
+            layout,
+            flags);
+    }
+};
+
+struct CD3DX12_RESOURCE_BARRIER : public D3D12_RESOURCE_BARRIER
+{
+    static inline D3D12_RESOURCE_BARRIER Transition(
+        ID3D12Resource* resource,
+        D3D12_RESOURCE_STATES stateBefore,
+        D3D12_RESOURCE_STATES stateAfter,
+        UINT subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES,
+        D3D12_RESOURCE_BARRIER_FLAGS flags = D3D12_RESOURCE_BARRIER_FLAG_NONE)
+    {
+        D3D12_RESOURCE_BARRIER barrier = {};
+        barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+        barrier.Flags = flags;
+        barrier.Transition.pResource = resource;
+        barrier.Transition.StateBefore = stateBefore;
+        barrier.Transition.StateAfter = stateAfter;
+        barrier.Transition.Subresource = subresource;
+        return barrier;
+    }
+};
+
+struct CD3DX12_RASTERIZER_DESC : public D3D12_RASTERIZER_DESC
+{
+    CD3DX12_RASTERIZER_DESC()
+    {
+        FillMode = D3D12_FILL_MODE_SOLID;
+        CullMode = D3D12_CULL_MODE_BACK;
+        FrontCounterClockwise = FALSE;
+        DepthBias = D3D12_DEFAULT_DEPTH_BIAS;
+        DepthBiasClamp = D3D12_DEFAULT_DEPTH_BIAS_CLAMP;
+        SlopeScaledDepthBias = D3D12_DEFAULT_SLOPE_SCALED_DEPTH_BIAS;
+        DepthClipEnable = TRUE;
+        MultisampleEnable = FALSE;
+        AntialiasedLineEnable = FALSE;
+        ForcedSampleCount = 0;
+        ConservativeRaster = D3D12_CONSERVATIVE_RASTERIZATION_MODE_OFF;
+    }
+
+    explicit CD3DX12_RASTERIZER_DESC(const D3D12_RASTERIZER_DESC& desc)
+    {
+        *static_cast<D3D12_RASTERIZER_DESC*>(this) = desc;
+    }
+
+    CD3DX12_RASTERIZER_DESC(CD3DX12_DEFAULT)
+    {
+        FillMode = D3D12_FILL_MODE_SOLID;
+        CullMode = D3D12_CULL_MODE_BACK;
+        FrontCounterClockwise = FALSE;
+        DepthBias = D3D12_DEFAULT_DEPTH_BIAS;
+        DepthBiasClamp = D3D12_DEFAULT_DEPTH_BIAS_CLAMP;
+        SlopeScaledDepthBias = D3D12_DEFAULT_SLOPE_SCALED_DEPTH_BIAS;
+        DepthClipEnable = TRUE;
+        MultisampleEnable = FALSE;
+        AntialiasedLineEnable = FALSE;
+        ForcedSampleCount = 0;
+        ConservativeRaster = D3D12_CONSERVATIVE_RASTERIZATION_MODE_OFF;
+    }
+};
+
+struct CD3DX12_BLEND_DESC : public D3D12_BLEND_DESC
+{
+    CD3DX12_BLEND_DESC()
+    {
+        AlphaToCoverageEnable = FALSE;
+        IndependentBlendEnable = FALSE;
+        const D3D12_RENDER_TARGET_BLEND_DESC defaultRenderTarget =
+        {
+            FALSE, FALSE,
+            D3D12_BLEND_ONE, D3D12_BLEND_ZERO, D3D12_BLEND_OP_ADD,
+            D3D12_BLEND_ONE, D3D12_BLEND_ZERO, D3D12_BLEND_OP_ADD,
+            D3D12_COLOR_WRITE_ENABLE_ALL
+        };
+        for (UINT i = 0; i < D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT; ++i)
+        {
+            RenderTarget[i] = defaultRenderTarget;
+        }
+    }
+
+    explicit CD3DX12_BLEND_DESC(const D3D12_BLEND_DESC& desc)
+    {
+        *static_cast<D3D12_BLEND_DESC*>(this) = desc;
+    }
+
+    CD3DX12_BLEND_DESC(CD3DX12_DEFAULT)
+    {
+        AlphaToCoverageEnable = FALSE;
+        IndependentBlendEnable = FALSE;
+        const D3D12_RENDER_TARGET_BLEND_DESC defaultRenderTarget =
+        {
+            FALSE, FALSE,
+            D3D12_BLEND_ONE, D3D12_BLEND_ZERO, D3D12_BLEND_OP_ADD,
+            D3D12_BLEND_ONE, D3D12_BLEND_ZERO, D3D12_BLEND_OP_ADD,
+            D3D12_COLOR_WRITE_ENABLE_ALL
+        };
+        for (UINT i = 0; i < D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT; ++i)
+        {
+            RenderTarget[i] = defaultRenderTarget;
+        }
+    }
+};
+
+struct CD3DX12_DEPTH_STENCIL_DESC : public D3D12_DEPTH_STENCIL_DESC
+{
+    CD3DX12_DEPTH_STENCIL_DESC()
+    {
+        DepthEnable = TRUE;
+        DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ALL;
+        DepthFunc = D3D12_COMPARISON_FUNC_LESS;
+        StencilEnable = FALSE;
+        StencilReadMask = D3D12_DEFAULT_STENCIL_READ_MASK;
+        StencilWriteMask = D3D12_DEFAULT_STENCIL_WRITE_MASK;
+        const D3D12_DEPTH_STENCILOP_DESC defaultStencilOp =
+        {
+            D3D12_STENCIL_OP_KEEP,
+            D3D12_STENCIL_OP_KEEP,
+            D3D12_STENCIL_OP_KEEP,
+            D3D12_COMPARISON_FUNC_ALWAYS
+        };
+        FrontFace = defaultStencilOp;
+        BackFace = defaultStencilOp;
+    }
+
+    explicit CD3DX12_DEPTH_STENCIL_DESC(const D3D12_DEPTH_STENCIL_DESC& desc)
+    {
+        *static_cast<D3D12_DEPTH_STENCIL_DESC*>(this) = desc;
+    }
+
+    CD3DX12_DEPTH_STENCIL_DESC(CD3DX12_DEFAULT)
+    {
+        DepthEnable = TRUE;
+        DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ALL;
+        DepthFunc = D3D12_COMPARISON_FUNC_LESS;
+        StencilEnable = FALSE;
+        StencilReadMask = D3D12_DEFAULT_STENCIL_READ_MASK;
+        StencilWriteMask = D3D12_DEFAULT_STENCIL_WRITE_MASK;
+        const D3D12_DEPTH_STENCILOP_DESC defaultStencilOp =
+        {
+            D3D12_STENCIL_OP_KEEP,
+            D3D12_STENCIL_OP_KEEP,
+            D3D12_STENCIL_OP_KEEP,
+            D3D12_COMPARISON_FUNC_ALWAYS
+        };
+        FrontFace = defaultStencilOp;
+        BackFace = defaultStencilOp;
+    }
+};
+
+struct ID3DBlob;
+
+struct CD3DX12_SHADER_BYTECODE : public D3D12_SHADER_BYTECODE
+{
+    CD3DX12_SHADER_BYTECODE()
+    {
+        pShaderBytecode = nullptr;
+        BytecodeLength = 0;
+    }
+
+    explicit CD3DX12_SHADER_BYTECODE(const D3D12_SHADER_BYTECODE& bytecode)
+    {
+        *static_cast<D3D12_SHADER_BYTECODE*>(this) = bytecode;
+    }
+
+    explicit CD3DX12_SHADER_BYTECODE(ID3DBlob* blob)
+    {
+        pShaderBytecode = blob ? blob->GetBufferPointer() : nullptr;
+        BytecodeLength = blob ? blob->GetBufferSize() : 0;
+    }
+};
+
+struct CD3DX12_DESCRIPTOR_RANGE : public D3D12_DESCRIPTOR_RANGE
+{
+    CD3DX12_DESCRIPTOR_RANGE()
+    {
+        Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 0, 0);
+    }
+
+    CD3DX12_DESCRIPTOR_RANGE(
+        D3D12_DESCRIPTOR_RANGE_TYPE rangeType,
+        UINT numDescriptors,
+        UINT baseShaderRegister,
+        UINT registerSpace = 0,
+        UINT offsetInDescriptors = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND)
+    {
+        Init(rangeType, numDescriptors, baseShaderRegister, registerSpace, offsetInDescriptors);
+    }
+
+    void Init(
+        D3D12_DESCRIPTOR_RANGE_TYPE rangeType,
+        UINT numDescriptors,
+        UINT baseShaderRegister,
+        UINT registerSpace = 0,
+        UINT offsetInDescriptors = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND)
+    {
+        RangeType = rangeType;
+        NumDescriptors = numDescriptors;
+        BaseShaderRegister = baseShaderRegister;
+        RegisterSpace = registerSpace;
+        OffsetInDescriptorsFromTableStart = offsetInDescriptors;
+    }
+};
+
+struct CD3DX12_ROOT_PARAMETER : public D3D12_ROOT_PARAMETER
+{
+    CD3DX12_ROOT_PARAMETER()
+    {
+        ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
+        ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
+        DescriptorTable.NumDescriptorRanges = 0;
+        DescriptorTable.pDescriptorRanges = nullptr;
+    }
+
+    void InitAsDescriptorTable(
+        UINT numDescriptorRanges,
+        const D3D12_DESCRIPTOR_RANGE* pDescriptorRanges,
+        D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL)
+    {
+        ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
+        ShaderVisibility = visibility;
+        DescriptorTable.NumDescriptorRanges = numDescriptorRanges;
+        DescriptorTable.pDescriptorRanges = pDescriptorRanges;
+    }
+
+    void InitAsConstantBufferView(
+        UINT shaderRegister,
+        UINT registerSpace = 0,
+        D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL)
+    {
+        ParameterType = D3D12_ROOT_PARAMETER_TYPE_CBV;
+        ShaderVisibility = visibility;
+        Descriptor.ShaderRegister = shaderRegister;
+        Descriptor.RegisterSpace = registerSpace;
+    }
+
+    void InitAsShaderResourceView(
+        UINT shaderRegister,
+        UINT registerSpace = 0,
+        D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL)
+    {
+        ParameterType = D3D12_ROOT_PARAMETER_TYPE_SRV;
+        ShaderVisibility = visibility;
+        Descriptor.ShaderRegister = shaderRegister;
+        Descriptor.RegisterSpace = registerSpace;
+    }
+
+    void InitAsUnorderedAccessView(
+        UINT shaderRegister,
+        UINT registerSpace = 0,
+        D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL)
+    {
+        ParameterType = D3D12_ROOT_PARAMETER_TYPE_UAV;
+        ShaderVisibility = visibility;
+        Descriptor.ShaderRegister = shaderRegister;
+        Descriptor.RegisterSpace = registerSpace;
+    }
+};
+
+struct CD3DX12_STATIC_SAMPLER_DESC : public D3D12_STATIC_SAMPLER_DESC
+{
+    CD3DX12_STATIC_SAMPLER_DESC()
+    {
+        ShaderRegister = 0;
+        Filter = D3D12_FILTER_ANISOTROPIC;
+        AddressU = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
+        AddressV = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
+        AddressW = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
+        MipLODBias = 0.0f;
+        MaxAnisotropy = 16;
+        ComparisonFunc = D3D12_COMPARISON_FUNC_LESS_EQUAL;
+        BorderColor = D3D12_STATIC_BORDER_COLOR_OPAQUE_WHITE;
+        MinLOD = 0.0f;
+        MaxLOD = D3D12_FLOAT32_MAX;
+        ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
+        RegisterSpace = 0;
+    }
+
+    CD3DX12_STATIC_SAMPLER_DESC(
+        UINT shaderRegister,
+        D3D12_FILTER filter = D3D12_FILTER_ANISOTROPIC,
+        D3D12_TEXTURE_ADDRESS_MODE addressU = D3D12_TEXTURE_ADDRESS_MODE_CLAMP,
+        D3D12_TEXTURE_ADDRESS_MODE addressV = D3D12_TEXTURE_ADDRESS_MODE_CLAMP,
+        D3D12_TEXTURE_ADDRESS_MODE addressW = D3D12_TEXTURE_ADDRESS_MODE_CLAMP,
+        FLOAT mipLODBias = 0.0f,
+        UINT maxAnisotropy = 16,
+        D3D12_COMPARISON_FUNC comparisonFunc = D3D12_COMPARISON_FUNC_LESS_EQUAL,
+        D3D12_STATIC_BORDER_COLOR borderColor = D3D12_STATIC_BORDER_COLOR_OPAQUE_WHITE,
+        FLOAT minLOD = 0.0f,
+        FLOAT maxLOD = D3D12_FLOAT32_MAX,
+        D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL,
+        UINT registerSpace = 0)
+    {
+        ShaderRegister = shaderRegister;
+        Filter = filter;
+        AddressU = addressU;
+        AddressV = addressV;
+        AddressW = addressW;
+        MipLODBias = mipLODBias;
+        MaxAnisotropy = maxAnisotropy;
+        ComparisonFunc = comparisonFunc;
+        BorderColor = borderColor;
+        MinLOD = minLOD;
+        MaxLOD = maxLOD;
+        ShaderVisibility = visibility;
+        RegisterSpace = registerSpace;
+    }
+};
+
+struct CD3DX12_ROOT_SIGNATURE_DESC : public D3D12_ROOT_SIGNATURE_DESC
+{
+    CD3DX12_ROOT_SIGNATURE_DESC()
+    {
+        Init(0, nullptr, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_NONE);
+    }
+
+    CD3DX12_ROOT_SIGNATURE_DESC(
+        UINT numParameters,
+        const D3D12_ROOT_PARAMETER* pParameters,
+        UINT numStaticSamplers,
+        const D3D12_STATIC_SAMPLER_DESC* pStaticSamplers,
+        D3D12_ROOT_SIGNATURE_FLAGS flags = D3D12_ROOT_SIGNATURE_FLAG_NONE)
+    {
+        Init(numParameters, pParameters, numStaticSamplers, pStaticSamplers, flags);
+    }
+
+    void Init(
+        UINT numParameters,
+        const D3D12_ROOT_PARAMETER* pParameters,
+        UINT numStaticSamplers,
+        const D3D12_STATIC_SAMPLER_DESC* pStaticSamplers,
+        D3D12_ROOT_SIGNATURE_FLAGS flags = D3D12_ROOT_SIGNATURE_FLAG_NONE)
+    {
+        NumParameters = numParameters;
+        this->pParameters = pParameters;
+        NumStaticSamplers = numStaticSamplers;
+        this->pStaticSamplers = pStaticSamplers;
+        Flags = flags;
+    }
+};
+


### PR DESCRIPTION
## Summary
- add a lightweight `d3dx12.h` implementation so the project can include the helper header

## Testing
- not run (header-only change)


------
https://chatgpt.com/codex/tasks/task_e_68da26655fd48332a62f54fa6f861c18