### PR TITLE
Improve fluid water rendering

### DIFF
--- a/DirectX12/FluidSystem.h
+++ b/DirectX12/FluidSystem.h
@@ -81,6 +81,15 @@ public:
         const DirectX::XMFLOAT3& camPos,
         float isoLevel);
 
+    // 水面のカラーや泡の強さを外部から調整できるようにする
+    void SetWaterAppearance(const DirectX::XMFLOAT3& shallowColor,
+        const DirectX::XMFLOAT3& deepColor,
+        float absorption,
+        float foamThreshold,
+        float foamStrength,
+        float reflectionStrength,
+        float specularPower);
+
     void StartDrag(int, int, class Camera*) {}
     void Drag(int, int, class Camera*) {}
     void EndDrag() {}
@@ -90,7 +99,10 @@ private:
     {
         DirectX::XMFLOAT4X4 InvViewProj; // ビュー射影逆行列（転置済み）
         DirectX::XMFLOAT4   CamRadius;   // カメラ座標と粒子半径
-        DirectX::XMFLOAT4   IsoCount;    // 等値面しきい値 / 粒子数 / レイマーチ係数
+        DirectX::XMFLOAT4   IsoCount;    // 等値面しきい値 / 粒子数 / レイマーチ係数 / 未使用
+        DirectX::XMFLOAT4   WaterDeep;   // 深い水の色 / w=吸収係数
+        DirectX::XMFLOAT4   WaterShallow;// 浅い水の色 / w=泡検出のしきい値
+        DirectX::XMFLOAT4   ShadingParams;// x=泡強度 y=反射割合 z=スペキュラ強度 w=時間
     };
 
     struct GPUParams
@@ -204,7 +216,14 @@ private:
     ID3D12Device* m_device = nullptr;
     DXGI_FORMAT   m_rtvFormat = DXGI_FORMAT_R8G8B8A8_UNORM;
 
-    float m_rayStepScale = 0.4f;
+    DirectX::XMFLOAT3 m_waterColorDeep;
+    DirectX::XMFLOAT3 m_waterColorShallow;
+    float m_waterAbsorption = 0.35f;
+    float m_foamCurvatureThreshold = 0.45f;
+    float m_foamStrength = 0.35f;
+    float m_reflectionStrength = 0.6f;
+    float m_specularPower = 64.0f;
+    float m_totalSimulatedTime = 0.0f;
 };
 
 // プリセットマテリアルの生成ヘルパー

--- a/DirectX12/GameScene.cpp
+++ b/DirectX12/GameScene.cpp
@@ -41,10 +41,18 @@ bool GameScene::Init() {
 	auto device = g_Engine->Device();
 	const DXGI_FORMAT rtvFormat = DXGI_FORMAT_R8G8B8A8_UNORM;
 
-	const UINT maxParticles = 5;
-	m_fluid.Init(device, rtvFormat, maxParticles, 0);
-	m_fluid.SpawnParticlesSphere(XMFLOAT3(0.0f,0.0f,0.0f),10.0f,50);
-	m_fluid.UseGPU(true);
+        const UINT maxParticles = 1024; // 60fpsを維持できるよう上限を適度に抑える
+        m_fluid.Init(device, rtvFormat, maxParticles, 0);
+        m_fluid.SetWaterAppearance(
+                XMFLOAT3(0.32f, 0.7f, 0.95f),  // 浅瀬カラー
+                XMFLOAT3(0.04f, 0.18f, 0.32f), // 深場カラー
+                0.28f,                         // 吸収係数
+                0.42f,                         // 泡しきい値
+                0.55f,                         // 泡強度
+                0.65f,                         // 反射割合
+                96.0f);                        // ハイライトの鋭さ
+        m_fluid.SpawnParticlesSphere(XMFLOAT3(0.0f, 0.6f, 0.0f), 1.1f, maxParticles);
+        m_fluid.UseGPU(true);
 
 
 	// 描画確認用のキューブを生成

--- a/DirectX12/MetaBallPS.hlsl
+++ b/DirectX12/MetaBallPS.hlsl
@@ -3,6 +3,9 @@ cbuffer MetaCB : register(b0)
     float4x4 invViewProj;   // ビュー射影逆行列
     float4   camRadius;     // xyz: カメラ位置, w: 粒子半径（描画用）
     float4   isoCount;      // x: しきい値, y: 粒子数, z: レイステップ係数, w: 未使用
+    float4   waterDeep;     // xyz: 深い水の色, w: 吸収係数
+    float4   waterShallow;  // xyz: 浅い水の色, w: 泡検出のしきい値
+    float4   shadingParams; // x: 泡強度, y: 反射割合, z: スペキュラパワー, w: 経過時間
 };
 
 struct ParticleMeta
@@ -32,6 +35,8 @@ float Field(float3 p, out float3 grad)
 
     const float iso = isoCount.x;
     // 粒子毎に滑らかなガウス核で寄与を合成する（SSFRの厚み感を少し意識）
+    const float kernelMul = 2.5f; // 遠すぎる粒子は無視して負荷を下げる
+
     [loop]
     for (uint i = 0; i < count; ++i)
     {
@@ -39,7 +44,17 @@ float Field(float3 p, out float3 grad)
         float  radius = max(Particles[i].r, 1e-4);
         float  r2 = radius * radius;
         float  dist2 = dot(d, d);
-        float  influence = exp(-dist2 / (r2));
+        float  cutoff2 = r2 * kernelMul * kernelMul;
+        if (dist2 > cutoff2)
+        {
+            continue;
+        }
+
+        float  influence = exp(-dist2 / r2);
+        if (influence < 1e-4)
+        {
+            continue;
+        }
         sum += influence;
         grad += (-2.0 * influence / r2) * d;
 
@@ -66,7 +81,7 @@ float4 main(VSOutput IN) : SV_TARGET
     float3 p = ro;
     float  d = 0.0;
     float3 grad = float3(0, 0, 0);
-    const int MAX_STEP = 96;
+    const int MAX_STEP = 80;
     const float stepScale = max(isoCount.z, 0.05);
 
     [loop]
@@ -87,28 +102,41 @@ float4 main(VSOutput IN) : SV_TARGET
 
     float3 n = (dot(grad, grad) > 1e-6) ? normalize(grad) : float3(0, 1, 0);
     float3 viewDir = normalize(ro - p);
-    float3 lightDir = normalize(float3(-0.3, 0.9, -0.2));
+    float3 lightDir = normalize(float3(-0.35, 0.9, -0.25));
 
     float diff = saturate(dot(n, lightDir));
-    float3 envColor = float3(0.05, 0.2, 0.35);
-    float3 baseWater = float3(0.15, 0.4, 0.85);
-    float3 shallowTint = float3(0.45, 0.75, 1.0);
 
-    // フレネルによる境界のハイライト（簡易版）
-    float fresnel = pow(1.0 - saturate(dot(n, viewDir)), 3.0);
-    float spec = pow(saturate(dot(reflect(-lightDir, n), viewDir)), 32.0);
+    // 水の厚さを簡易的に推定して色の吸収を行う
+    float viewDist = length(ro - p);
+    float absorption = exp(-viewDist * waterDeep.w);
+    float3 baseWater = lerp(waterDeep.xyz, waterShallow.xyz, absorption);
 
-    // 勾配の長さで泡っぽいハイライトを加算（密度が高い境界ほど白く）
-    float foam = saturate(1.0 - length(grad) * 0.25);
+    // 周囲光の色を少し青寄りに設定して水らしい落ち着いたトーンに
+    float3 envColor = float3(0.05, 0.16, 0.28);
 
-    float3 color = envColor * (1.0 - fresnel);
-    color += lerp(baseWater, shallowTint, diff) * (0.35 + diff * 0.65);
-    color += fresnel * float3(0.6, 0.85, 1.0);
-    color += spec * 0.25;
-    color += foam * 0.1;
+    float3 diffuse = baseWater * (0.25 + diff * 0.75);
 
-    float alpha = saturate(0.55 + fresnel * 0.35);
-    color = lerp(envColor, color, alpha); // 透過時は背景色と自然に混ざるように調整
+    // フレネルで反射寄りにする領域を抽出し、反射強度はパラメータで制御
+    float fresnel = pow(1.0 - saturate(dot(n, viewDir)), 5.0);
+    float3 reflection = lerp(baseWater, float3(0.75, 0.9, 1.0), shadingParams.y);
+
+    // 泡は勾配の強さと簡易波動（正弦波）で変動させる
+    float curvature = saturate(1.0 - length(grad) * waterShallow.w);
+    float foamWave = 0.5 + 0.5 * sin(dot(p.xz, float2(0.8, 0.45)) * 2.2 + shadingParams.w * 1.4);
+    float foamMask = saturate((curvature - 0.25) * 2.0) * foamWave;
+
+    float specPower = max(shadingParams.z, 4.0);
+    float spec = pow(saturate(dot(reflect(-lightDir, n), viewDir)), specPower);
+
+    float3 color = diffuse;
+    color += reflection * fresnel;
+    color += spec * 0.35;
+    color = lerp(envColor, color, 0.65);
+    color += shadingParams.x * foamMask * float3(1.0, 1.0, 1.0);
+
+    // 厚さによる透過感を持たせるためアルファも吸収とフレネルで調整
+    float alpha = saturate(0.35 + absorption * 0.45 + fresnel * 0.35);
+    color = lerp(envColor, color, alpha);
 
     return float4(saturate(color), alpha);
 


### PR DESCRIPTION
## Summary
- add configurable water appearance controls on the fluid system and document them in Japanese
- enhance the metaball pixel shader with absorption-based coloring, foam animation, and kernel culling to improve performance and visual quality
- tune the default game scene fluid setup for a denser pool while keeping the frame rate target by capping particles and adjusting spawn parameters

## Testing
- not run (Windows-only project)


------
https://chatgpt.com/codex/tasks/task_e_68da2834a02c83329588599800854ecf