### PR TITLE
Fix blur shader sampling for compatibility

### DIFF
--- a/DirectX12/BlurPS.hlsl
+++ b/DirectX12/BlurPS.hlsl
@@ -4,7 +4,7 @@ SamplerState samLinear : register(s0);
 cbuffer BlurCB : register(b0)
 {
     float2 texelSize; // 1/width, 1/height
-    float2 dir; // (1,0)=��, (0,1)=�c
+    float2 dir; // (1,0)=, (0,1)=c
 };
 
 struct VSOut
@@ -15,18 +15,20 @@ struct VSOut
 
 float4 main(VSOut i) : SV_Target
 {
-    // 5tap �K�E�V�A�����i�y�ʁj
+    // 5tap KEVAiyʁj
     static const float w[5] = { 0.204164f, 0.304005f, 0.193783f, 0.072184f, 0.025864f };
     float2 o = dir * texelSize;
-    float v = SrcTex.SampleLevel(samLinear, i.uv, 0);
-    v += SrcTex.SampleLevel(samLinear, i.uv + o * 1, 0) * w[1];
-    v += SrcTex.SampleLevel(samLinear, i.uv - o * 1, 0) * w[1];
-    v += SrcTex.SampleLevel(samLinear, i.uv + o * 2, 0) * w[2];
-    v += SrcTex.SampleLevel(samLinear, i.uv - o * 2, 0) * w[2];
-    v += SrcTex.SampleLevel(samLinear, i.uv + o * 3, 0) * w[3];
-    v += SrcTex.SampleLevel(samLinear, i.uv - o * 3, 0) * w[3];
-    v += SrcTex.SampleLevel(samLinear, i.uv + o * 4, 0) * w[4];
-    v += SrcTex.SampleLevel(samLinear, i.uv - o * 4, 0) * w[4];
+    // SampleLevel を使うと一部のターゲットで "texlod" 命令が生成されるためエラーになる。
+    // このぼかし処理では通常の Sample で問題ないので、LOD 指定を外す。
+    float v = SrcTex.Sample(samLinear, i.uv);
+    v += SrcTex.Sample(samLinear, i.uv + o * 1) * w[1];
+    v += SrcTex.Sample(samLinear, i.uv - o * 1) * w[1];
+    v += SrcTex.Sample(samLinear, i.uv + o * 2) * w[2];
+    v += SrcTex.Sample(samLinear, i.uv - o * 2) * w[2];
+    v += SrcTex.Sample(samLinear, i.uv + o * 3) * w[3];
+    v += SrcTex.Sample(samLinear, i.uv - o * 3) * w[3];
+    v += SrcTex.Sample(samLinear, i.uv + o * 4) * w[4];
+    v += SrcTex.Sample(samLinear, i.uv - o * 4) * w[4];
     return float4(v, 0, 0, 0);
 }
 
@@ -40,7 +42,7 @@ float4 main(VSOut i) : SV_Target
 
 //float main(float2 uv : TEXCOORD) : SV_Target
 //{
-//    // 5-tap Gaussian�i�����j
+//    // 5-tap Gaussianij
 //    const float w[5] = { 0.227027, 0.194595, 0.121622, 0.054054, 0.016216 };
 //    float a = Src.SampleLevel(samLinear, uv, 0).r * w[0];
 //    [unroll]


### PR DESCRIPTION
## Summary
- replace SampleLevel calls in BlurPS with standard Sample to avoid texlod instruction on unsupported targets
- add explanatory Japanese comments describing the change

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da82d641fc83328792b77436486982