### PR TITLE
Fix GPU fluid grid reset to avoid device hang

### DIFF
--- a/DirectX12/ClearGridCS.hlsl
+++ b/DirectX12/ClearGridCS.hlsl
@@ -1,0 +1,44 @@
+// グリッドの粒子カウントとテーブルをゼロ初期化するコンピュートシェーダー
+#define MAX_PARTICLES_PER_CELL 64
+
+cbuffer SPHParams : register(b0)
+{
+    float restDensity;
+    float particleMass;
+    float viscosity;
+    float stiffness;
+    float radius;
+    float timeStep;
+    uint  particleCount;
+    uint  pad0;
+    float3 gridMin;
+    float  pad1;
+    uint3  gridDim;
+    uint   pad2;
+};
+
+cbuffer ViewProjCB : register(b1)
+{
+    float4x4 viewProj;
+};
+
+RWStructuredBuffer<uint> gridCount : register(u2);
+RWStructuredBuffer<uint> gridTable : register(u3);
+
+[numthreads(256,1,1)]
+void CSMain(uint3 id : SV_DispatchThreadID)
+{
+    uint cellCount = gridDim.x * gridDim.y * gridDim.z;
+    uint index = id.x;
+
+    if (index < cellCount)
+    {
+        gridCount[index] = 0;
+    }
+
+    uint tableCount = cellCount * MAX_PARTICLES_PER_CELL;
+    if (index < tableCount)
+    {
+        gridTable[index] = 0;
+    }
+}

--- a/DirectX12/FluidSystem.h
+++ b/DirectX12/FluidSystem.h
@@ -143,6 +143,8 @@ private:
         D3D12_RESOURCE_STATES state = D3D12_RESOURCE_STATE_COMMON;
     };
 
+    static constexpr UINT kMaxParticlesPerCell = 64; // グリッド1セルが保持できる粒子数の上限
+
     void UpdateGridSettings();
     void ApplyExternalOperationsCPU(float dt);
     void StepCPU(float dt);
@@ -195,6 +197,7 @@ private:
     Microsoft::WRL::ComPtr<ID3D12RootSignature> m_computeRootSignature;
     std::unique_ptr<ComputePipelineState> m_buildGridPipeline;
     std::unique_ptr<ComputePipelineState> m_particlePipeline;
+    std::unique_ptr<ComputePipelineState> m_clearGridPipeline;
     Microsoft::WRL::ComPtr<ID3D12CommandAllocator> m_computeAllocator;
     Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList> m_computeCommandList;
     Microsoft::WRL::ComPtr<ID3D12Fence> m_computeFence;


### PR DESCRIPTION
## Summary
- add a dedicated compute shader to clear the fluid grid buffers each frame
- rebuild GPU resource setup to include the new clear pass and guard against missing pipelines
- zero the grid on the GPU before building it to prevent stale counts that caused device hangs

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68da951c867c83329844748b79c3ad61