### PR TITLE
Fix InterlockedExchange usage in BuildGridCS

### DIFF
--- a/DirectX12/BuildGridCS.hlsl
+++ b/DirectX12/BuildGridCS.hlsl
@@ -55,7 +55,9 @@ void CSMain(uint3 id : SV_DispatchThreadID)
     // gridCountを飽和させて以降のアクセスが配列境界を越えないようにする。
     if (writeIdx >= MAX_PARTICLES_PER_CELL)
     {
-        InterlockedExchange(outGridCount[cellId], MAX_PARTICLES_PER_CELL);
+        uint originalCount;
+        // InterlockedExchangeは3つ目の引数に元の値を受け取る必要があるため、ダミーの変数を用意する。
+        InterlockedExchange(outGridCount[cellId], MAX_PARTICLES_PER_CELL, originalCount);
         return;
     }
 


### PR DESCRIPTION
## Summary
- add the missing original value output parameter when clamping grid counts
- document the reason for the dummy variable in Japanese to match existing comments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dab04e15448332b9bd91bc62c2d1a6