### PR TITLE
Fix depth stencil format mismatch in DirectX 12 pipelines

### DIFF
--- a/DirectX12/DebugCube.cpp
+++ b/DirectX12/DebugCube.cpp
@@ -44,6 +44,7 @@ DebugCube::DebugCube() {
     m_pipelineState->SetRootSignature(m_rootSignature->Get());
     m_pipelineState->SetVS(L"SimpleVS.cso");
     m_pipelineState->SetPS(L"ColorPS.cso");
+    m_pipelineState->SetDepthStencilFormat(DXGI_FORMAT_D32_FLOAT); // 深度バッファ(D32)とPSOの設定を一致させる
     m_pipelineState->Create(D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE);
 }
 

--- a/DirectX12/FluidSystem.cpp
+++ b/DirectX12/FluidSystem.cpp
@@ -929,7 +929,8 @@ bool FluidSystem::CreateMetaPipeline(ID3D12Device* device, DXGI_FORMAT rtvFormat
         return false;
     }
 
-    if (!graphics::MetaBallPipeline::CreatePipelineState(device, m_metaRootSignature.Get(), rtvFormat, m_metaPipelineState))
+    // 深度ステンシルビューはD32形式なので、PSOにも同じフォーマットを渡しておく
+    if (!graphics::MetaBallPipeline::CreatePipelineState(device, m_metaRootSignature.Get(), rtvFormat, DXGI_FORMAT_D32_FLOAT, m_metaPipelineState))
     {
         printf("FluidSystem: MetaBall PSO Create failed\n");
         cleanupMetaResources();

--- a/DirectX12/MetaBallPipelineState.cpp
+++ b/DirectX12/MetaBallPipelineState.cpp
@@ -164,6 +164,7 @@ namespace graphics {
         ID3D12Device* device,
         ID3D12RootSignature* rootSig,
         DXGI_FORMAT rtvFormat,
+        DXGI_FORMAT dsvFormat,
         ComPtr<ID3D12PipelineState>& outPSO)
     {
         if (!device || !rootSig)
@@ -193,6 +194,7 @@ namespace graphics {
         desc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
         desc.NumRenderTargets = 1;
         desc.RTVFormats[0] = rtvFormat;
+        desc.DSVFormat = dsvFormat; // 深度バッファの実際のフォーマット(D32)と一致させる
         desc.SampleMask = UINT_MAX;
         desc.SampleDesc.Count = 1;
         auto rasterizerDesc = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);

--- a/DirectX12/MetaBallPipelineState.h
+++ b/DirectX12/MetaBallPipelineState.h
@@ -17,6 +17,7 @@ namespace graphics {
         static bool CreatePipelineState(ID3D12Device* device,
             ID3D12RootSignature* rootSig,
             DXGI_FORMAT rtvFormat,
+            DXGI_FORMAT dsvFormat,
             ComPtr<ID3D12PipelineState>& outPSO);
     };
 

--- a/DirectX12/PipelineState.cpp
+++ b/DirectX12/PipelineState.cpp
@@ -92,6 +92,11 @@ void PipelineState::SetPS(std::wstring filePath)
     }
 }
 
+void PipelineState::SetDepthStencilFormat(DXGI_FORMAT format)
+{
+    desc.DSVFormat = format; // フレームバッファの深度バッファ形式とPSOを揃える
+}
+
 void PipelineState::Create(D3D12_PRIMITIVE_TOPOLOGY_TYPE type)
 {
     desc.PrimitiveTopologyType = type;

--- a/DirectX12/PipelineState.h
+++ b/DirectX12/PipelineState.h
@@ -6,22 +6,22 @@
 class PipelineState
 {
 public:
-	PipelineState();	// ƒRƒ“ƒXƒgƒ‰ƒNƒ^‚Å‚ ‚é’ö“x‚Ìİ’è‚ğ‚·‚é
-	bool IsValid();		// ¶¬‚É¬Œ÷‚µ‚½‚©‚Ç‚¤‚©‚ğ•Ô‚·
+	PipelineState();	// RXgN^Å‚xÌİ’
+	bool IsValid();		// ÉÇ‚Ô‚
 
-	void SetInputLayout(D3D12_INPUT_LAYOUT_DESC layout);		// “ü—ÍƒŒƒCƒAƒEƒg‚ğİ’è
-	void SetRootSignature(ID3D12RootSignature* rootSignature);	// ƒ‹[ƒgƒVƒOƒlƒ`ƒƒ‚ğİ’è
-	void SetVS(std::wstring filePath);							// ’¸“_ƒVƒF[ƒ_[‚ğİ’è
-	void SetPS(std::wstring filePath);							// ƒsƒNƒZƒ‹ƒVƒF[ƒ_[‚ğİ’è
-	void Create(D3D12_PRIMITIVE_TOPOLOGY_TYPE type);												// ƒpƒCƒvƒ‰ƒCƒ“ƒXƒe[ƒg‚ğ¶¬
-
+	void SetInputLayout(D3D12_INPUT_LAYOUT_DESC layout);            // ÍƒCAEgİ’
+	void SetRootSignature(ID3D12RootSignature* rootSignature);      // [gVOl`İ’
+	void SetVS(std::wstring filePath);                                                      // VSã‚·ã‚§ãƒ¼ãƒ€ãƒ¼ã‚’è¨­å®š
+	void SetPS(std::wstring filePath);                                                      // PSã‚·ã‚§ãƒ¼ãƒ€ãƒ¼ã‚’è¨­å®š
+	void SetDepthStencilFormat(DXGI_FORMAT format);                                         // æ·±åº¦ã‚¹ãƒ†ãƒ³ã‚·ãƒ«ãƒ•ã‚©ãƒ¼ãƒãƒƒãƒˆè¨­å®š
+	void Create(D3D12_PRIMITIVE_TOPOLOGY_TYPE type);                                        // ã‚°ãƒ©ãƒ•ã‚£ãƒƒã‚¯ã‚¹ãƒ‘ã‚¤ãƒ—ãƒ©ã‚¤ãƒ³ã‚’ç”Ÿæˆ
 	ID3D12PipelineState* Get();
 
 private:
-	bool m_IsValid = false;										// ¶¬‚É¬Œ÷‚µ‚½‚©‚Ç‚¤‚©
-	D3D12_GRAPHICS_PIPELINE_STATE_DESC desc = {};				// ƒpƒCƒvƒ‰ƒCƒ“ƒXƒe[ƒg‚Ìİ’è
-	ComPtr<ID3D12PipelineState> m_pPipelineState = nullptr;		// ƒpƒCƒvƒ‰ƒCƒ“ƒXƒe[ƒg
-	ComPtr<ID3DBlob> m_pVsBlob;									// ’¸“_ƒVƒF[ƒ_[
-	ComPtr<ID3DBlob> m_pPSBlob;									// ƒsƒNƒZƒ‹ƒVƒF[ƒ_[
+	bool m_IsValid = false;										// ÉÇ‚
+	D3D12_GRAPHICS_PIPELINE_STATE_DESC desc = {};				// pCvCXe[gÌİ’
+	ComPtr<ID3D12PipelineState> m_pPipelineState = nullptr;		// pCvCXe[g
+	ComPtr<ID3DBlob> m_pVsBlob;									// _VF[_[
+	ComPtr<ID3DBlob> m_pPSBlob;									// sNZVF[_[
 };
 


### PR DESCRIPTION
## Summary
- set the meta ball graphics pipeline to use the D32 depth-stencil format when creating the PSO
- expose a helper on the generic pipeline state to configure the DSV format and align the debug cube pipeline with the D32 depth buffer

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68db413636b08332a703169edba0e4da