### PR TITLE
Optimize metaball rendering with spatial grid

### DIFF
--- a/DirectX12/FluidSystem.h
+++ b/DirectX12/FluidSystem.h
@@ -102,6 +102,8 @@ private:
         DirectX::XMFLOAT4X4 ViewProj;    // ビュー射影行列（転置済み）
         DirectX::XMFLOAT4   CamRadius;   // カメラ座標と粒子半径
         DirectX::XMFLOAT4   IsoCount;    // 等値面しきい値 / 粒子数 / レイマーチ係数 / 未使用
+        DirectX::XMFLOAT4   GridMinCell; // グリッドの最小座標 / セルサイズ
+        DirectX::XMUINT4    GridDimInfo; // グリッドの寸法 / 総セル数（w）
         DirectX::XMFLOAT4   WaterDeep;   // 深い水の色 / w=吸収係数
         DirectX::XMFLOAT4   WaterShallow;// 浅い水の色 / w=泡検出のしきい値
         DirectX::XMFLOAT4   ShadingParams;// x=泡強度 y=反射割合 z=スペキュラ強度 w=時間
@@ -190,6 +192,8 @@ private:
     GPUBufferHandle m_gpuParticleBuffers[2];
     Microsoft::WRL::ComPtr<ID3D12Resource> m_gpuGridCount;
     Microsoft::WRL::ComPtr<ID3D12Resource> m_gpuGridTable;
+    DescriptorHandle* m_gpuGridCountSRV = nullptr;
+    DescriptorHandle* m_gpuGridTableSRV = nullptr;
     DescriptorHandle* m_gpuGridCountUAV = nullptr;
     DescriptorHandle* m_gpuGridTableUAV = nullptr;
     Microsoft::WRL::ComPtr<ID3D12Resource> m_gpuUpload;

--- a/DirectX12/MetaBallPipelineState.cpp
+++ b/DirectX12/MetaBallPipelineState.cpp
@@ -119,13 +119,17 @@ namespace graphics {
             return false;
         }
 
-        // SRV(t0) + CBV(b0)
-        CD3DX12_DESCRIPTOR_RANGE ranges[1];
+        // SRV(t0) 粒子メタ情報, SRV(t1) グリッドテーブル, SRV(t2) グリッドカウンタ, CBV(b0)
+        CD3DX12_DESCRIPTOR_RANGE ranges[3];
         ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0);
+        ranges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 1);
+        ranges[2].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 2);
 
-        CD3DX12_ROOT_PARAMETER params[2];
+        CD3DX12_ROOT_PARAMETER params[4];
         params[0].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_PIXEL);
         params[1].InitAsConstantBufferView(0, 0, D3D12_SHADER_VISIBILITY_PIXEL);
+        params[2].InitAsDescriptorTable(1, &ranges[1], D3D12_SHADER_VISIBILITY_PIXEL);
+        params[3].InitAsDescriptorTable(1, &ranges[2], D3D12_SHADER_VISIBILITY_PIXEL);
 
         CD3DX12_ROOT_SIGNATURE_DESC desc(
             _countof(params), params,


### PR DESCRIPTION
## Summary
- extend the fluid rendering constants to include spatial grid metadata and bind the GPU grid SRVs before issuing the metaball draw
- register shader-resource views for the grid buffers, update resource barriers for pixel shader access, and tighten GPU resource validation
- rewrite the MetaBall pixel shader to ray march through spatial grid neighbor cells instead of brute-force sampling every particle

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db46def1488332bb1071afa3334204