### PR TITLE
Add fluid composite pass and restructure rendering flow

### DIFF
--- a/DirectX12/DescriptorHeap.h
+++ b/DirectX12/DescriptorHeap.h
@@ -18,7 +18,8 @@ class DescriptorHeap
 public:
 	DescriptorHeap(); // コンストラクタで生す
 	ID3D12DescriptorHeap* GetHeap(); // ィスクリプタヒプを返す
-	DescriptorHandle* Register(Texture2D* texture); // クスチャーをディスクリプタヒプに登録しハンドルを返す
+        DescriptorHandle* Register(Texture2D* texture); // クスチャーをディスクリプタヒプに登録しハンドルを返す
+    DescriptorHandle* Register(ID3D12Resource* resource, const D3D12_SHADER_RESOURCE_VIEW_DESC& desc);
     DescriptorHandle* RegisterBuffer(
             ID3D12Resource* resource,
             UINT            numElements,

--- a/DirectX12/Engine.h
+++ b/DirectX12/Engine.h
@@ -27,8 +27,11 @@ public: // 外からアクセスするためのGetter
 	ID3D12Device6*				Device();
 	ID3D12GraphicsCommandList*	CommandList();
 	UINT						CurrentBackBufferIndex();
-    D3D12_CPU_DESCRIPTOR_HANDLE CurrentBackBufferView() const;
-	D3D12_CPU_DESCRIPTOR_HANDLE DepthStencilView() const;
+        D3D12_CPU_DESCRIPTOR_HANDLE CurrentBackBufferView() const;
+        D3D12_CPU_DESCRIPTOR_HANDLE DepthStencilView() const;
+        ID3D12Resource*                     RenderTargetResource(UINT index) const;
+        ID3D12Resource*                     CurrentRenderTargetResource() const;
+        ID3D12Resource*                     DepthStencilBuffer() const;
 
 	UINT						FrameBufferWidth() const; // フレームバッファの幅を取得
 	UINT						FrameBufferHeight() const; // フレームバッファの高さを取得

--- a/DirectX12/FluidSystem.h
+++ b/DirectX12/FluidSystem.h
@@ -78,10 +78,16 @@ public:
 
     void Simulate(ID3D12GraphicsCommandList* cmd, float dt);
     void Render(ID3D12GraphicsCommandList* cmd,
-        const DirectX::XMFLOAT4X4& invViewProj,
+        const DirectX::XMFLOAT4X4& view,
+        const DirectX::XMFLOAT4X4& proj,
         const DirectX::XMFLOAT4X4& viewProj,
         const DirectX::XMFLOAT3& camPos,
         float isoLevel);
+
+    void Composite(ID3D12GraphicsCommandList* cmd,
+        ID3D12Resource* sceneColor,
+        ID3D12Resource* sceneDepth,
+        D3D12_CPU_DESCRIPTOR_HANDLE sceneRTV);
 
     // 水面のカラーや泡の強さを外部から調整できるようにする
     void SetWaterAppearance(const DirectX::XMFLOAT3& shallowColor,
@@ -205,6 +211,12 @@ private:
     DescriptorHandle* m_normalUAV = nullptr;
     DescriptorHandle* m_thicknessSRV = nullptr;
     DescriptorHandle* m_thicknessUAV = nullptr;
+
+    DescriptorHandle* m_sceneColorSRV = nullptr;
+    DescriptorHandle* m_sceneDepthSRV = nullptr;
+    Microsoft::WRL::ComPtr<ID3D12Resource> m_sceneColorCopy;
+    D3D12_RESOURCE_STATES m_sceneColorCopyState = D3D12_RESOURCE_STATE_COMMON;
+    D3D12_RESOURCE_STATES m_sceneDepthState = D3D12_RESOURCE_STATE_DEPTH_WRITE;
 
     Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> m_ssfrRtvHeap;            // RTV専用ヒープ
     UINT m_ssfrRtvDescriptorSize = 0;


### PR DESCRIPTION
## Summary
- render fluid intermediate textures before scene geometry and add full-screen composite pass
- introduce scene color/depth descriptors and copy resources for fluid blending
- expose engine resource accessors and update descriptor heap utilities for reuse

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68db68f4657c8332b13a538f3300e364