### PR TITLE
Fix fluid rendering bindings and include engine header

### DIFF
--- a/DirectX12/FluidSystem.cpp
+++ b/DirectX12/FluidSystem.cpp
@@ -1519,9 +1519,10 @@ bool FluidSystem::CreateSSFRResources(ID3D12Device* device, DXGI_FORMAT rtvForma
     // 粒子描画ルートシグネチャ
     {
         CD3DX12_DESCRIPTOR_RANGE uavRanges[3];
-        uavRanges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_UAV, 1, 0);
-        uavRanges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_UAV, 1, 1);
-        uavRanges[2].Init(D3D12_DESCRIPTOR_RANGE_TYPE_UAV, 1, 2);
+        // ピクセルシェーダーの RTV0 と競合しないよう、UAV はレジスタ u1 以降へ配置
+        uavRanges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_UAV, 1, 1);
+        uavRanges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_UAV, 1, 2);
+        uavRanges[2].Init(D3D12_DESCRIPTOR_RANGE_TYPE_UAV, 1, 3);
 
         CD3DX12_ROOT_PARAMETER params[4];
         params[0].InitAsConstantBufferView(0, 0, D3D12_SHADER_VISIBILITY_ALL);

--- a/DirectX12/GameScene.cpp
+++ b/DirectX12/GameScene.cpp
@@ -1,6 +1,7 @@
 #include "Game.h"
 #include "SceneManager.h"
 #include "GameScene.h"
+#include "Engine.h" // エンジンの各種リソースへアクセスするためのヘッダーを追加
 #include <DirectXMath.h>
 #include "SharedStruct.h"
 #include "App.h"
@@ -104,6 +105,7 @@ void GameScene::Draw() {
         auto cameraPos = camObj->GetPosition();
 
         // 1. 流体の中間テクスチャを更新（粒子深度・平滑化・法線など）
+        // ピクセルシェーダーで参照する行列やカメラ位置を流体レンダリングへ渡す
         m_fluid.Render(cmd, viewMatrixFloat, projMatrixFloat, viewProjFloat, cameraPos, 1.0f);
 
         // 2. シーンジオメトリを通常のRTV/DSVへ描画
@@ -113,6 +115,7 @@ void GameScene::Draw() {
         }
 
         // 3. シーンカラー／深度と流体情報を合成して最終カラーを出力
+        // レンダーターゲットと深度バッファを用いて流体の最終合成を実行
         m_fluid.Composite(
                 cmd,
                 g_Engine->CurrentRenderTargetResource(),

--- a/DirectX12/SSFRParticlePS.hlsl
+++ b/DirectX12/SSFRParticlePS.hlsl
@@ -1,7 +1,7 @@
 #include "SharedStruct.hlsli"
 
-RWTexture2D<uint> g_FluidDepthUAV    : register(u0); // R32_UINT に線形深度を格納（float を asuint で詰め込む）
-RWTexture2D<uint> g_FluidThicknessUAV : register(u1); // 厚みも同様に float ビット列で蓄積
+RWTexture2D<uint> g_FluidDepthUAV    : register(u1); // SV_Target0 と衝突しないよう UAV は u1 から割り当てる
+RWTexture2D<uint> g_FluidThicknessUAV : register(u2); // 厚みも同様に float ビット列で蓄積
 
 struct PSIn
 {


### PR DESCRIPTION
## Summary
- include Engine.h in GameScene so the scene can access render target helpers during compositing
- shift SSFR particle pixel shader UAV bindings to avoid collisions with render target outputs
- update the fluid system root signature to use the new UAV register assignments

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db7e731bfc83328a1de12852e7feeb