### PR TITLE
Fix scene initialization to restore rendering

### DIFF
--- a/DirectX12/SceneManager.h
+++ b/DirectX12/SceneManager.h
@@ -18,6 +18,9 @@ private:
     FadeController m_fade;
     std::string m_pendingScene;
 
+    // シーン名から生成・初期化済みのシーンを取得するユーティリティ
+    std::unique_ptr<BaseScene> CreateInitializedScene(const std::string& name);
+
 public:
     void RegisterScene(const std::string& name, SceneFactory factory);
     void ChangeScene(const std::string& name);


### PR DESCRIPTION
## Summary
- create a helper in SceneManager to instantiate and initialize scenes when switching
- ensure ChangeScene, PushScene, and fade transitions only push initialized scenes
- prevent blank rendering by running each scene's Init routine before Draw is called

## Testing
- not run (not supported in container)

------
https://chatgpt.com/codex/tasks/task_e_68dff845d5b4833286366f6638770972