### PR TITLE
Fix SSFR UAV clear handles and pipeline depth format

### DIFF
--- a/DirectX12/FluidSystem.h
+++ b/DirectX12/FluidSystem.h
@@ -252,6 +252,11 @@ private:
     D3D12_CPU_DESCRIPTOR_HANDLE m_smoothedDepthRTV = {};
     D3D12_CPU_DESCRIPTOR_HANDLE m_thicknessRTV = {};
 
+    Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> m_ssfrCpuUavHeap;         // UAVクリア用CPUヒープ
+    UINT m_ssfrCpuUavDescriptorSize = 0;
+    D3D12_CPU_DESCRIPTOR_HANDLE m_particleDepthUavCpuHandle = {};
+    D3D12_CPU_DESCRIPTOR_HANDLE m_smoothedDepthUavCpuHandle = {};
+
     D3D12_RESOURCE_STATES m_particleDepthState = D3D12_RESOURCE_STATE_COMMON;
     D3D12_RESOURCE_STATES m_smoothedDepthState = D3D12_RESOURCE_STATE_COMMON;
     D3D12_RESOURCE_STATES m_normalState = D3D12_RESOURCE_STATE_COMMON;


### PR DESCRIPTION
## Summary
- add a CPU-visible UAV descriptor heap for SSFR resources and reuse its handles when clearing
- mark the particle rendering PSO with a DSV format of UNKNOWN to match the lack of a bound depth buffer

## Testing
- not run (not supported in container)


------
https://chatgpt.com/codex/tasks/task_e_68e325c37f6083329f98f2c0ecbf30dc