### PR TITLE
Rebind depth stencil after fluid compositing

### DIFF
--- a/DirectX12/FluidSystem.cpp
+++ b/DirectX12/FluidSystem.cpp
@@ -705,6 +705,10 @@ void FluidSystem::Composite(ID3D12GraphicsCommandList* cmd,
         D3D12_RESOURCE_STATE_COPY_DEST);
     cmd->ResourceBarrier(1, &resetSceneCopy);
     m_sceneColorCopyState = D3D12_RESOURCE_STATE_COPY_DEST;
+
+    // 11. 合成でDSVを外したため通常描画に戻る前に深度ステンシルを再バインドする
+    auto depthHandle = g_Engine->DepthStencilView();
+    cmd->OMSetRenderTargets(1, &sceneRTV, FALSE, &depthHandle);
 }
 
 void FluidSystem::SetWaterAppearance(const XMFLOAT3& shallowColor,


### PR DESCRIPTION
## Summary
- rebind the depth stencil view after the fluid composite pass so later draws use the expected DSV

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e3287401a88332b47da6612c2f2b62