### PR TITLE
Refactor GameScene fluid prototype

### DIFF
--- a/DirectX12/DebugCube.cpp
+++ b/DirectX12/DebugCube.cpp
@@ -58,6 +58,11 @@ DebugCube::~DebugCube() {
     }
 }
 
+void DebugCube::SetWorldMatrix(const DirectX::XMMATRIX& world)
+{
+    m_world = world;
+}
+
 void DebugCube::Update(float /*deltaTime*/) {
     // カメラの行列を定数バッファへ設定
     auto cam = g_Engine->GetObj<Camera>("Camera");

--- a/DirectX12/DebugCube.h
+++ b/DirectX12/DebugCube.h
@@ -22,6 +22,7 @@ private:
 public:
     DebugCube();
     ~DebugCube();
+    void SetWorldMatrix(const DirectX::XMMATRIX& world);
     void Update(float deltaTime) override;
     void Render(ID3D12GraphicsCommandList* cmd) override;
 };

--- a/DirectX12/FluidSystem.cpp
+++ b/DirectX12/FluidSystem.cpp
@@ -1,1998 +1,65 @@
 #include "FluidSystem.h"
+#include "Camera.h"
 #include "Engine.h"
-#include "RandomUtil.h"
-#include "ComputePipelineState.h"
-#include <d3dcompiler.h>
-#include <d3dx12.h>
-#include <cstdio>
 #include <algorithm>
 #include <cmath>
+#include <cstring>
 #include <random>
-#include <filesystem>
-
-#pragma comment(lib, "d3dcompiler.lib")
 
 using namespace DirectX;
 
 namespace
 {
-    std::wstring ResolveShaderPath(const std::wstring& fileName)
-    {
-        std::vector<std::filesystem::path> searchDirectories;
-        searchDirectories.push_back(std::filesystem::current_path());
-
-        std::filesystem::path exeDir;
-#ifdef _WIN32
-        wchar_t path[MAX_PATH] = {};
-        DWORD length = GetModuleFileNameW(nullptr, path, MAX_PATH);
-        if (length > 0 && length < MAX_PATH)
-        {
-            exeDir = std::filesystem::path(path).parent_path();
-        }
-#endif
-        if (!exeDir.empty())
-        {
-            auto iter = exeDir;
-            for (int i = 0; i < 4 && !iter.empty(); ++i)
-            {
-                searchDirectories.push_back(iter);
-                iter = iter.parent_path();
-            }
-        }
-
-        for (const auto& dir : searchDirectories)
-        {
-            std::filesystem::path candidate = dir / fileName;
-            if (std::filesystem::exists(candidate))
-            {
-                return candidate.wstring();
-            }
-        }
-        return fileName;
-    }
-
-    bool LoadOrCompileShader(const std::wstring& sourceName, const char* entryPoint, const char* target,
-        Microsoft::WRL::ComPtr<ID3DBlob>& outBlob)
-    {
-        std::filesystem::path sourcePath = ResolveShaderPath(sourceName);
-        std::filesystem::path csoPath = sourcePath;
-        csoPath.replace_extension(L".cso");
-
-        if (std::filesystem::exists(csoPath))
-        {
-            if (SUCCEEDED(D3DReadFileToBlob(csoPath.c_str(), &outBlob)))
-            {
-                return true;
-            }
-        }
-
-        if (!std::filesystem::exists(sourcePath))
-        {
-            wprintf(L"FluidSystem: シェーダーファイル %ls が見つかりません\n", sourceName.c_str());
-            return false;
-        }
-
-        UINT flags = D3DCOMPILE_ENABLE_STRICTNESS;
-#ifdef _DEBUG
-        flags |= D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
-#endif
-
-        Microsoft::WRL::ComPtr<ID3DBlob> error;
-        HRESULT hr = D3DCompileFromFile(
-            sourcePath.c_str(),
-            nullptr,
-            D3D_COMPILE_STANDARD_FILE_INCLUDE,
-            entryPoint,
-            target,
-            flags,
-            0,
-            &outBlob,
-            &error);
-
-        if (FAILED(hr))
-        {
-            if (error)
-            {
-                printf("FluidSystem: %s\n", static_cast<const char*>(error->GetBufferPointer()));
-            }
-            else
-            {
-                wprintf(L"FluidSystem: シェーダー %ls のコンパイルに失敗しました (0x%08X)\n", sourcePath.c_str(), hr);
-            }
-            return false;
-        }
-
-        if (!csoPath.empty())
-        {
-            D3DWriteBlobToFile(outBlob.Get(), csoPath.c_str(), TRUE);
-        }
-
-        return true;
-    }
-
-    // GPUバッファ用の粒子構造体
-    struct GPUFluidParticle
-    {
-        XMFLOAT3 position;
-        float    pad0 = 0.0f;
-        XMFLOAT3 velocity;
-        float    pad1 = 0.0f;
-    };
-
-    struct ParticleMetaGPU
-    {
-        XMFLOAT3 position;
-        float    radius;
-    };
-
-    // PBFカーネル関数（Poly6）
-    float Poly6(float r, float h)
-    {
-        if (r >= h)
-        {
-            return 0.0f;
-        }
-        float diff = h * h - r * r;
-        float coeff = 315.0f / (64.0f * XM_PI * std::pow(h, 9));
-        return coeff * diff * diff * diff;
-    }
-
-    // PBFカーネルの勾配（Spiky）
-    XMFLOAT3 GradSpiky(const XMFLOAT3& rij, float r, float h)
-    {
-        if (r <= 1e-6f || r >= h)
-        {
-            return XMFLOAT3(0.0f, 0.0f, 0.0f);
-        }
-        float coeff = -45.0f / (XM_PI * std::pow(h, 6));
-        float scale = coeff * (h - r) * (h - r) / r;
-        return XMFLOAT3(rij.x * scale, rij.y * scale, rij.z * scale);
-    }
-
-    inline float Length(const XMFLOAT3& v)
-    {
-        return std::sqrt(v.x * v.x + v.y * v.y + v.z * v.z);
-    }
-}
-
-FluidMaterial CreateFluidMaterial(FluidMaterialPreset preset)
-{
-    FluidMaterial material{};
-    switch (preset)
-    {
-    case FluidMaterialPreset::Magma:
-        material.restDensity = 1500.0f;
-        material.particleMass = 1.2f;
-        material.smoothingRadius = 0.14f;
-        material.viscosity = 0.25f;      // 高い粘性でゆっくり流れる
-        material.stiffness = 350.0f;
-        material.renderRadius = 0.12f;
-        material.lambdaEpsilon = 150.0f;
-        material.xsphC = 0.15f;
-        material.solverIterations = 6;
-        break;
-    case FluidMaterialPreset::Water:
-    default:
-        material = FluidMaterial();
-        break;
-    }
-    return material;
+    constexpr float kGravity = -9.8f;       // 重力加速度
+    constexpr float kWallThickness = 0.0f;  // AABB扱いなので実体厚みは不要
 }
 
 FluidSystem::FluidSystem()
-    : m_spatialGrid(0.12f)
+    : m_world(XMMatrixIdentity())
 {
-    m_material = CreateFluidMaterial(FluidMaterialPreset::Water);
-    m_boundsMin = XMFLOAT3(-2.0f, 0.0f, -2.0f);
-    m_boundsMax = XMFLOAT3(2.0f, 4.0f, 2.0f);
-    m_gridDim = XMUINT3(1, 1, 1);
-    // 見た目系のデフォルト値を設定
-    m_waterColorDeep = XMFLOAT3(0.07f, 0.22f, 0.38f);
-    m_waterColorShallow = XMFLOAT3(0.25f, 0.55f, 0.95f);
 }
 
-FluidSystem::~FluidSystem()
+bool FluidSystem::Init(ID3D12Device* device, const Bounds& initialBounds, UINT particleCount)
 {
-    // GPU用フェンスイベントを確実にクローズしてリークを防ぐ
-    if (m_computeFenceEvent)
-    {
-        CloseHandle(m_computeFenceEvent);
-        m_computeFenceEvent = nullptr;
-    }
-}
+    (void)device; // DirectXリソース生成は Engine 内のヘルパーを利用するため未使用
 
-void FluidSystem::Init(ID3D12Device* device, DXGI_FORMAT rtvFormat, UINT maxParticles, UINT threadGroupCount)
-{
-    (void)threadGroupCount;
-    m_device = device;
-    m_rtvFormat = rtvFormat;
-    m_maxParticles = std::max<UINT>(1u, maxParticles);
-    m_cpuParticles.clear();
-    m_cpuParticles.reserve(m_maxParticles);
-    m_particleCount = 0;
+    m_bounds = initialBounds;
+    InitializeParticles(particleCount);
 
-    UpdateGridSettings();
-
-    CreateGPUResources(device);
-
-    if (!CreateSSFRResources(device, rtvFormat))
-    {
-        printf("FluidSystem ERROR: SSFR用リソースの初期化に失敗したため描画品質を低下させます\n");
-    }
-
-    // GPU・CPUリソースの生成が完了したタイミングで初期化済みフラグを立てる
-    m_initialized = true;
-
-    // ひとまず初期状態として軽く粒子を生成しておく
-    SpawnParticlesSphere(XMFLOAT3(0.0f, 1.0f, 0.0f), 0.6f, m_maxParticles / 2);
-
-    UpdateParticleBuffer();
-}
-
-void FluidSystem::UseGPU(bool enable)
-{
-    if (!m_initialized)
-    {
-        return;
-    }
-
-    if (enable && !m_gpuAvailable)
-    {
-        CreateGPUResources(m_device);
-    }
-
-    m_useGPU = enable && m_gpuAvailable;
-}
-
-FluidSimulationMode FluidSystem::Mode() const
-{
-    return (m_useGPU && m_gpuAvailable) ? FluidSimulationMode::GPU : FluidSimulationMode::CPU;
-}
-
-void FluidSystem::SetMaterialPreset(FluidMaterialPreset preset)
-{
-    SetMaterial(CreateFluidMaterial(preset));
-}
-
-void FluidSystem::SetMaterial(const FluidMaterial& material)
-{
-    m_material = material;
-    m_spatialGrid.SetCellSize(m_material.smoothingRadius);
-    UpdateGridSettings();
-
-    m_particleCount = static_cast<UINT>(std::min<size_t>(m_cpuParticles.size(), m_maxParticles));
-
-    m_cpuDirty = true;
-    m_gpuDirty = true;
-
-    // マテリアル変更時はGPUリソースも再作成して整合を取る
-    if (m_device)
-    {
-        CreateGPUResources(m_device);
-        CreateSSFRResources(m_device, m_rtvFormat);
-    }
-}
-
-void FluidSystem::SetSimulationBounds(const XMFLOAT3& minBound, const XMFLOAT3& maxBound)
-{
-    // 境界設定を更新し、SPHの探索グリッドも再構築する
-    m_boundsMin = minBound;
-    m_boundsMax = maxBound;
-    UpdateGridSettings();
-}
-
-// ============================
-// 流体生成
-// ============================
-void FluidSystem::SpawnParticlesSphere(const XMFLOAT3& center, float radius, UINT count)
-{
-    if (!m_initialized || count == 0)
-    {
-        return;
-    }
-
-    std::mt19937 rng{ std::random_device{}() };
-    std::uniform_real_distribution<float> dist(0.0f, 1.0f);
-
-    for (UINT i = 0; i < count && m_particleCount < m_maxParticles; ++i)
-    {
-        float u = dist(rng);
-        float v = dist(rng);
-        float theta = 2.0f * XM_PI * u;
-        float phi = std::acos(2.0f * v - 1.0f);
-        float r = radius * std::cbrt(dist(rng));
-
-        XMFLOAT3 offset{
-            r * std::sin(phi) * std::cos(theta),
-            r * std::cos(phi),
-            r * std::sin(phi) * std::sin(theta)
-        };
-
-        FluidParticle particle{};
-        particle.position = XMFLOAT3(center.x + offset.x, center.y + offset.y, center.z + offset.z);
-        particle.velocity = XMFLOAT3(0.0f, 0.0f, 0.0f);
-        particle.predicted = particle.position;
-        particle.density = m_material.restDensity;
-        particle.lambda = 0.0f;
-        particle.collisionMask = 0;
-
-        m_cpuParticles.push_back(particle);
-        ++m_particleCount;
-    }
-
-    m_cpuDirty = true;
-    m_gpuDirty = true;
-}
-
-// ============================
-// 流体削除
-// ============================
-void FluidSystem::RemoveParticlesSphere(const XMFLOAT3& center, float radius)
-{
-    if (!m_initialized || m_particleCount == 0)
-    {
-        return;
-    }
-
-    float r2 = radius * radius;
-    auto it = std::remove_if(m_cpuParticles.begin(), m_cpuParticles.end(), [&](const FluidParticle& p)
-        {
-            XMFLOAT3 diff{ p.position.x - center.x, p.position.y - center.y, p.position.z - center.z };
-            float len2 = diff.x * diff.x + diff.y * diff.y + diff.z * diff.z;
-            return len2 <= r2;
-        });
-    m_cpuParticles.erase(it, m_cpuParticles.end());
-    m_particleCount = static_cast<UINT>(std::min<size_t>(m_cpuParticles.size(), m_maxParticles));
-
-    m_cpuDirty = true;
-    m_gpuDirty = true;
-}
-
-
-void FluidSystem::QueueGather(const XMFLOAT3& target, float radius, float strength)
-{
-    m_gatherOps.push_back({ target, radius, strength });
-}
-
-void FluidSystem::QueueSplash(const XMFLOAT3& position, float radius, float impulse)
-{
-    m_splashOps.push_back({ position, radius, impulse });
-}
-
-void FluidSystem::QueueDirectionalImpulse(const XMFLOAT3& center, float radius, const XMFLOAT3& direction, float strength)
-{
-    XMVECTOR dirVec = XMLoadFloat3(&direction);
-    if (XMVectorGetX(XMVector3LengthSq(dirVec)) < 1e-6f)
-    {
-        return;
-    }
-    DirectionalImpulseOperation op{};
-    op.center = center;
-    op.radius = radius;
-    op.direction = direction;
-    op.strength = strength;
-    m_directionalOps.push_back(op);
-}
-
-void FluidSystem::ClearDynamicOperations()
-{
-    m_gatherOps.clear();
-    m_splashOps.clear();
-    m_directionalOps.clear();
-}
-
-float FluidSystem::EffectiveTimeStep(float dt) const
-{
-    const float minStep = 1.0f / 240.0f;
-    const float maxStep = 1.0f / 30.0f;
-    return std::clamp(dt, minStep, maxStep);
-}
-
-void FluidSystem::Simulate(ID3D12GraphicsCommandList* cmd, float dt)
-{
-    if (!m_initialized)
-    {
-        return;
-    }
-
-    m_particleCount = static_cast<UINT>(std::min<size_t>(m_cpuParticles.size(), m_maxParticles));
-    if (m_particleCount == 0)
-    {
-        return;
-    }
-
-    float step = EffectiveTimeStep(dt);
-
-    if (Mode() == FluidSimulationMode::GPU)
-    {
-        if (!HasValidGPUResources())
-        {
-            // GPU用リソースが欠けている場合は安全のためCPUシミュレーションへ切り替える
-            printf("FluidSystem ERROR: 必要なGPUリソースが未初期化のためCPUシミュレーションにフォールバックします\n");
-            m_gpuAvailable = false;
-
-            ApplyExternalOperationsCPU(step);
-            StepCPU(step);
-            UpdateParticleBuffer();
-            m_activeMetaSRV = m_cpuMetaSRV;
-            return;
-        }
-
-        // 前フレームの結果を読み戻してCPU側と同期
-        if (m_pendingReadback)
-        {
-            ReadbackGPUToCPU();
-        }
-
-        ApplyExternalOperationsCPU(step);
-        UpdateComputeParams(step);
-
-        // GPU用コマンドリストをリセットして記録を開始
-        ID3D12GraphicsCommandList* computeCmd = BeginComputeCommandList();
-        if (!computeCmd)
-        {
-            // 取得に失敗した場合はGPUモードを諦めてCPUシミュレーションにフォールバック
-            StepCPU(step);
-            UpdateParticleBuffer();
-            m_activeMetaSRV = m_cpuMetaSRV;
-            return;
-        }
-
-        UploadCPUToGPU(computeCmd);
-        StepGPU(computeCmd, step);
-        SubmitComputeCommandList();
-        m_activeMetaSRV = m_gpuMetaSRV;
-    }
-    else
-    {
-        ApplyExternalOperationsCPU(step);
-        StepCPU(step);
-        UpdateParticleBuffer();
-        m_activeMetaSRV = m_cpuMetaSRV;
-    }
-
-    // 累積時間はシェーダー側のアニメーションに利用する
-    m_totalSimulatedTime += step;
-    if (m_totalSimulatedTime > 10000.0f)
-    {
-        m_totalSimulatedTime = std::fmod(m_totalSimulatedTime, 10000.0f);
-    }
-}
-
-
-void FluidSystem::Render(ID3D12GraphicsCommandList* cmd,
-    const XMFLOAT4X4& view,
-    const XMFLOAT4X4& proj,
-    const XMFLOAT4X4& viewProj,
-    const XMFLOAT3& camPos,
-    float isoLevel)
-{
-    (void)isoLevel;
-    (void)camPos;
-
-    if (!m_initialized || !cmd || m_particleCount == 0 ||
-        !m_particleRootSignature || !m_particlePipelineState ||
-        !m_blurPipelineState || !m_normalPipelineState ||
-        !m_particleDepthTexture || !m_smoothedDepthTexture ||
-        !m_normalTexture || !m_thicknessTexture ||
-        !m_particleDepthSRV || !m_particleDepthUAV || !m_smoothedDepthSRV || !m_smoothedDepthUAV ||
-        !m_normalSRV || !m_normalUAV || !m_thicknessSRV || !m_thicknessUAV)
-    {
-        return;
-    }
-
-    if (!m_activeMetaSRV)
-    {
-        // 粒子SRVが未設定の場合は描画できないため早期リターン
-        return;
-    }
-
-    UINT frameIndex = g_Engine->CurrentBackBufferIndex();
-    auto& cameraCB = m_cameraCB[frameIndex];
-    if (!cameraCB)
-    {
-        return;
-    }
-
-    UINT width = std::max<UINT>(1u, g_Engine->FrameBufferWidth());
-    UINT height = std::max<UINT>(1u, g_Engine->FrameBufferHeight());
-
-    SSFRCameraConstants* camera = cameraCB->GetPtr<SSFRCameraConstants>();
-    XMMATRIX viewMatrix = XMLoadFloat4x4(&view);
-    XMMATRIX projMatrix = XMLoadFloat4x4(&proj);
-    XMMATRIX viewProjMatrix = XMLoadFloat4x4(&viewProj);
-
-    XMStoreFloat4x4(&camera->View, XMMatrixTranspose(viewMatrix));
-    XMStoreFloat4x4(&camera->Proj, XMMatrixTranspose(projMatrix));
-    XMStoreFloat4x4(&camera->ViewProj, XMMatrixTranspose(viewProjMatrix));
-    camera->ScreenSize = XMFLOAT2(static_cast<float>(width), static_cast<float>(height));
-    camera->InvScreen = XMFLOAT2(1.0f / static_cast<float>(width), 1.0f / static_cast<float>(height));
-    camera->NearZ = 0.1f;
-    camera->FarZ = 1000.0f;
-    float f0 = std::clamp(m_reflectionStrength, 0.0f, 1.0f);
-    camera->IorF0 = XMFLOAT3(f0, f0, f0);
-    camera->Absorption = m_waterAbsorption;
-
-    // ブラー定数は1度だけ設定しておけばよいので、呼び出し毎に更新不要
-    if (m_blurParamsCB)
-    {
-        auto* blur = m_blurParamsCB->GetPtr<SSFRBlurParams>();
-        blur->Sigma = std::max(0.1f, blur->Sigma);
-        blur->DepthK = std::max(0.01f, blur->DepthK);
-        blur->NormalK = std::max(0.1f, blur->NormalK);
-    }
-
-    ID3D12DescriptorHeap* heaps[] = { g_Engine->CbvSrvUavHeap()->GetHeap() };
-    cmd->SetDescriptorHeaps(1, heaps);
-
-    auto transition = [&](std::unique_ptr<Texture2D>& texture, D3D12_RESOURCE_STATES targetState, D3D12_RESOURCE_STATES& currentState)
-    {
-        if (texture && currentState != targetState)
-        {
-            auto barrier = CD3DX12_RESOURCE_BARRIER::Transition(texture->Resource(), currentState, targetState);
-            cmd->ResourceBarrier(1, &barrier);
-            currentState = targetState;
-        }
-    };
-
-    // 粒子深度パス（UAVへ書き込み）
-    transition(m_particleDepthTexture, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, m_particleDepthState);
-    transition(m_smoothedDepthTexture, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, m_smoothedDepthState);
-    transition(m_thicknessTexture, D3D12_RESOURCE_STATE_RENDER_TARGET, m_thicknessState);
-
-    const float clearDepth[4] = { 1.0f, 1.0f, 1.0f, 1.0f };
-    // ClearUnorderedAccessViewFloat ではCPU可視のUAVハンドルが必要なので、専用ヒープで確保したハンドルを使用する
-    cmd->ClearUnorderedAccessViewFloat(m_particleDepthUAV->HandleGPU, m_particleDepthUavCpuHandle, m_particleDepthTexture->Resource(), clearDepth, 0, nullptr);
-    cmd->ClearUnorderedAccessViewFloat(m_smoothedDepthUAV->HandleGPU, m_smoothedDepthUavCpuHandle, m_smoothedDepthTexture->Resource(), clearDepth, 0, nullptr);
-    const float clearThickness[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
-    cmd->ClearRenderTargetView(m_thicknessRTV, clearThickness, 0, nullptr);
-
-    cmd->SetGraphicsRootSignature(m_particleRootSignature.Get());
-    cmd->SetPipelineState(m_particlePipelineState.Get());
-    cmd->SetGraphicsRootConstantBufferView(0, cameraCB->GetAddress());
-    // StructuredBuffer<ParticleData> を VS へ渡す
-    cmd->SetGraphicsRootDescriptorTable(1, m_activeMetaSRV->HandleGPU);
-    cmd->SetGraphicsRootDescriptorTable(2, m_particleDepthUAV->HandleGPU);
-    cmd->SetGraphicsRootDescriptorTable(3, m_smoothedDepthUAV->HandleGPU);
-    cmd->SetGraphicsRootDescriptorTable(4, m_thicknessUAV->HandleGPU);
-    cmd->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-    cmd->DrawInstanced(3, 1, 0, 0);
-
-    // 深度平滑化（コンピュート）
-    transition(m_particleDepthTexture, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, m_particleDepthState);
-    transition(m_smoothedDepthTexture, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, m_smoothedDepthState);
-
-    if (m_blurPipelineState)
-    {
-        cmd->SetComputeRootSignature(m_blurRootSignature.Get());
-        cmd->SetPipelineState(m_blurPipelineState.Get());
-        cmd->SetComputeRootDescriptorTable(0, m_particleDepthSRV->HandleGPU);
-        cmd->SetComputeRootDescriptorTable(1, m_particleDepthSRV->HandleGPU);
-        cmd->SetComputeRootDescriptorTable(2, m_smoothedDepthUAV->HandleGPU);
-        // CameraCB (register b0) を必ずバインドする
-        cmd->SetComputeRootConstantBufferView(3, cameraCB->GetAddress());
-        if (m_blurParamsCB)
-        {
-            // BilateralParams (register b1) をバインドする
-            cmd->SetComputeRootConstantBufferView(4, m_blurParamsCB->GetAddress());
-        }
-        UINT groupX = (width + 15) / 16;
-        UINT groupY = (height + 15) / 16;
-        cmd->Dispatch(groupX, groupY, 1);
-    }
-
-    // 法線生成
-    transition(m_smoothedDepthTexture, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, m_smoothedDepthState);
-    transition(m_normalTexture, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, m_normalState);
-
-    if (m_normalPipelineState)
-    {
-        cmd->SetComputeRootSignature(m_normalRootSignature.Get());
-        cmd->SetPipelineState(m_normalPipelineState.Get());
-        cmd->SetComputeRootDescriptorTable(0, m_smoothedDepthSRV->HandleGPU);
-        cmd->SetComputeRootDescriptorTable(1, m_normalUAV->HandleGPU);
-        cmd->SetComputeRootConstantBufferView(2, cameraCB->GetAddress());
-        UINT groupX = (width + 31) / 32;
-        UINT groupY = (height + 31) / 32;
-        cmd->Dispatch(groupX, groupY, 1);
-    }
-
-    // 合成のために必要なリソース状態へ戻す
-    transition(m_particleDepthTexture, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, m_particleDepthState);
-    transition(m_smoothedDepthTexture, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, m_smoothedDepthState);
-    transition(m_normalTexture, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, m_normalState);
-    transition(m_thicknessTexture, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, m_thicknessState);
-}
-
-void FluidSystem::Composite(ID3D12GraphicsCommandList* cmd,
-    ID3D12Resource* sceneColor,
-    ID3D12Resource* sceneDepth,
-    D3D12_CPU_DESCRIPTOR_HANDLE sceneRTV)
-{
-    if (!m_initialized || !cmd || m_particleCount == 0 ||
-        !sceneColor || !sceneDepth ||
-        !m_sceneColorCopy || !m_sceneColorSRV || !m_sceneDepthSRV ||
-        !m_smoothedDepthSRV || !m_normalSRV || !m_thicknessSRV ||
-        !m_compositeRootSignature || !m_compositePipelineState)
-    {
-        return;
-    }
-
-    UINT frameIndex = g_Engine->CurrentBackBufferIndex();
-    auto& cameraCB = m_cameraCB[frameIndex];
-    if (!cameraCB)
-    {
-        return;
-    }
-
-    ID3D12DescriptorHeap* heaps[] = { g_Engine->CbvSrvUavHeap()->GetHeap() };
-    cmd->SetDescriptorHeaps(1, heaps);
-
-    // 1. シーンカラーをサンプルするためバックバッファをコピー元へ遷移
-    auto toCopySource = CD3DX12_RESOURCE_BARRIER::Transition(
-        sceneColor,
-        D3D12_RESOURCE_STATE_RENDER_TARGET,
-        D3D12_RESOURCE_STATE_COPY_SOURCE);
-    cmd->ResourceBarrier(1, &toCopySource);
-
-    // 2. コピー先テクスチャを COPY_DEST へ揃える
-    if (m_sceneColorCopyState != D3D12_RESOURCE_STATE_COPY_DEST)
-    {
-        auto toCopyDest = CD3DX12_RESOURCE_BARRIER::Transition(
-            m_sceneColorCopy.Get(),
-            m_sceneColorCopyState,
-            D3D12_RESOURCE_STATE_COPY_DEST);
-        cmd->ResourceBarrier(1, &toCopyDest);
-        m_sceneColorCopyState = D3D12_RESOURCE_STATE_COPY_DEST;
-    }
-
-    // 3. バックバッファの内容をシェーダー参照用テクスチャにコピー
-    cmd->CopyResource(m_sceneColorCopy.Get(), sceneColor);
-
-    // 4. コピー結果をピクセルシェーダー用に遷移
-    auto toSceneSRV = CD3DX12_RESOURCE_BARRIER::Transition(
-        m_sceneColorCopy.Get(),
-        D3D12_RESOURCE_STATE_COPY_DEST,
-        D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
-    cmd->ResourceBarrier(1, &toSceneSRV);
-    m_sceneColorCopyState = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
-
-    // 5. バックバッファを再度レンダーターゲット状態に戻す
-    auto toRenderTarget = CD3DX12_RESOURCE_BARRIER::Transition(
-        sceneColor,
-        D3D12_RESOURCE_STATE_COPY_SOURCE,
-        D3D12_RESOURCE_STATE_RENDER_TARGET);
-    cmd->ResourceBarrier(1, &toRenderTarget);
-
-    // 6. 深度バッファをピクセルシェーダーから参照できる状態へ
-    if (m_sceneDepthState != D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE)
-    {
-        auto toDepthSRV = CD3DX12_RESOURCE_BARRIER::Transition(
-            sceneDepth,
-            m_sceneDepthState,
-            D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
-        cmd->ResourceBarrier(1, &toDepthSRV);
-        m_sceneDepthState = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
-    }
-
-    // 7. 合成先のRTVを再設定（深度は不要なので未設定）
-    cmd->OMSetRenderTargets(1, &sceneRTV, FALSE, nullptr);
-
-    // 8. フルスクリーン三角形でシーンカラーと流体テクスチャを合成
-    cmd->SetGraphicsRootSignature(m_compositeRootSignature.Get());
-    cmd->SetPipelineState(m_compositePipelineState.Get());
-    cmd->SetGraphicsRootDescriptorTable(0, m_smoothedDepthSRV->HandleGPU);
-    cmd->SetGraphicsRootDescriptorTable(1, m_normalSRV->HandleGPU);
-    cmd->SetGraphicsRootDescriptorTable(2, m_thicknessSRV->HandleGPU);
-    cmd->SetGraphicsRootDescriptorTable(3, m_sceneDepthSRV->HandleGPU);
-    cmd->SetGraphicsRootDescriptorTable(4, m_sceneColorSRV->HandleGPU);
-    cmd->SetGraphicsRootConstantBufferView(5, cameraCB->GetAddress());
-    cmd->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-    cmd->DrawInstanced(3, 1, 0, 0);
-
-    // 9. 深度バッファを次のフレームで書き込めるように戻す
-    auto toDepthWrite = CD3DX12_RESOURCE_BARRIER::Transition(
-        sceneDepth,
-        D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
-        D3D12_RESOURCE_STATE_DEPTH_WRITE);
-    cmd->ResourceBarrier(1, &toDepthWrite);
-    m_sceneDepthState = D3D12_RESOURCE_STATE_DEPTH_WRITE;
-
-    // 10. シーンカラーのコピーを次フレームのコピー先に戻す
-    auto resetSceneCopy = CD3DX12_RESOURCE_BARRIER::Transition(
-        m_sceneColorCopy.Get(),
-        D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
-        D3D12_RESOURCE_STATE_COPY_DEST);
-    cmd->ResourceBarrier(1, &resetSceneCopy);
-    m_sceneColorCopyState = D3D12_RESOURCE_STATE_COPY_DEST;
-
-    // 11. 合成でDSVを外したため通常描画に戻る前に深度ステンシルを再バインドする
-    auto depthHandle = g_Engine->DepthStencilView();
-    cmd->OMSetRenderTargets(1, &sceneRTV, FALSE, &depthHandle);
-}
-
-void FluidSystem::SetWaterAppearance(const XMFLOAT3& shallowColor,
-    const XMFLOAT3& deepColor,
-    float absorption,
-    float foamThreshold,
-    float foamStrength,
-    float reflectionStrength,
-    float specularPower)
-{
-    // ゲーム側で水の雰囲気をコントロールしやすいようにクランプしてから採用
-    m_waterColorShallow = shallowColor;
-    m_waterColorDeep = deepColor;
-    m_waterAbsorption = std::max(absorption, 0.0f);
-    m_foamCurvatureThreshold = std::clamp(foamThreshold, 0.05f, 1.5f);
-    m_foamStrength = std::clamp(foamStrength, 0.0f, 1.0f);
-    m_reflectionStrength = std::clamp(reflectionStrength, 0.0f, 1.0f);
-    m_specularPower = std::max(specularPower, 1.0f);
-}
-
-void FluidSystem::ApplyExternalOperationsCPU(float dt)
-{
-    if (m_cpuParticles.empty())
-    {
-        return;
-    }
-
-    bool modified = false;
-
-    // 集束処理
-    for (const auto& op : m_gatherOps)
-    {
-        XMVECTOR target = XMLoadFloat3(&op.target);
-        for (auto& particle : m_cpuParticles)
-        {
-            XMVECTOR pos = XMLoadFloat3(&particle.position);
-            XMVECTOR diff = XMVectorSubtract(target, pos);
-            float dist = XMVectorGetX(XMVector3Length(diff));
-            if (dist < op.radius && dist > 1e-5f)
-            {
-                float weight = 1.0f - (dist / op.radius);
-                float accel = op.strength * weight;
-                XMVECTOR dir = XMVector3Normalize(diff);
-                XMVECTOR vel = XMLoadFloat3(&particle.velocity);
-                vel = XMVectorAdd(vel, XMVectorScale(dir, accel * dt));
-                XMStoreFloat3(&particle.velocity, vel);
-                modified = true;
-            }
-        }
-    }
-
-    // 発散処理は1回で取り除く
-    if (!m_splashOps.empty())
-    {
-        for (const auto& op : m_splashOps)
-        {
-            XMVECTOR origin = XMLoadFloat3(&op.origin);
-            for (auto& particle : m_cpuParticles)
-            {
-                XMVECTOR pos = XMLoadFloat3(&particle.position);
-                XMVECTOR diff = XMVectorSubtract(pos, origin);
-                float dist = XMVectorGetX(XMVector3Length(diff));
-                if (dist < op.radius && dist > 1e-5f)
-                {
-                    float weight = 1.0f - (dist / op.radius);
-                    XMVECTOR dir = XMVector3Normalize(diff);
-                    XMVECTOR vel = XMLoadFloat3(&particle.velocity);
-                    vel = XMVectorAdd(vel, XMVectorScale(dir, op.impulse * weight));
-                    XMStoreFloat3(&particle.velocity, vel);
-                    modified = true;
-                }
-            }
-        }
-        m_splashOps.clear();
-    }
-
-    // 指向性インパルス（例：前方へ飛ばす操作）
-    if (!m_directionalOps.empty())
-    {
-        for (const auto& op : m_directionalOps)
-        {
-            XMVECTOR center = XMLoadFloat3(&op.center);
-            XMVECTOR dir = XMLoadFloat3(&op.direction);
-            dir = XMVector3Normalize(dir);
-            for (auto& particle : m_cpuParticles)
-            {
-                XMVECTOR pos = XMLoadFloat3(&particle.position);
-                XMVECTOR diff = XMVectorSubtract(pos, center);
-                float dist = XMVectorGetX(XMVector3Length(diff));
-                if (dist < op.radius)
-                {
-                    float weight = 1.0f - (dist / op.radius);
-                    XMVECTOR vel = XMLoadFloat3(&particle.velocity);
-                    vel = XMVectorAdd(vel, XMVectorScale(dir, op.strength * weight));
-                    XMStoreFloat3(&particle.velocity, vel);
-                    modified = true;
-                }
-            }
-        }
-        m_directionalOps.clear();
-    }
-
-    if (modified)
-    {
-        m_cpuDirty = true;
-    }
-}
-
-void FluidSystem::StepCPU(float dt)
-{
-    if (m_cpuParticles.empty())
-    {
-        return;
-    }
-
-    const float h = m_material.smoothingRadius;
-    const float mass = m_material.particleMass;
-    const float restDensity = m_material.restDensity;
-    const float epsilon = m_material.lambdaEpsilon;
-    const float sCorrK = -0.001f;
-    const float sCorrN = 4.0f;
-    const float deltaQ = 0.3f * h;
-    const float invRestDensity = 1.0f / restDensity;
-    const XMFLOAT3 gravity = XMFLOAT3(0.0f, -9.8f, 0.0f);
-
-    m_spatialGrid.Clear();
-
-    // 外力適用と予測位置計算
-    for (size_t i = 0; i < m_cpuParticles.size(); ++i)
-    {
-        auto& particle = m_cpuParticles[i];
-        particle.collisionMask = 0;
-        XMVECTOR vel = XMLoadFloat3(&particle.velocity);
-        XMVECTOR grav = XMLoadFloat3(&gravity);
-        vel = XMVectorAdd(vel, XMVectorScale(grav, dt));
-        XMStoreFloat3(&particle.velocity, vel);
-
-        XMVECTOR pos = XMLoadFloat3(&particle.position);
-        XMVECTOR pred = XMVectorAdd(pos, XMVectorScale(vel, dt));
-        XMStoreFloat3(&particle.predicted, pred);
-        particle.lambda = 0.0f;
-
-        m_spatialGrid.Insert(i, particle.predicted);
-    }
-
-    std::vector<size_t> neighbors;
-    neighbors.reserve(64);
-    std::vector<size_t> xsphNeighbors;
-    xsphNeighbors.reserve(64);
-
-    for (int iteration = 0; iteration < m_material.solverIterations; ++iteration)
-    {
-        // λ計算
-        for (size_t i = 0; i < m_cpuParticles.size(); ++i)
-        {
-            FluidParticle& pi = m_cpuParticles[i];
-            neighbors.clear();
-            m_spatialGrid.Query(pi.predicted, h, neighbors);
-
-            float density = 0.0f;
-            for (size_t idx : neighbors)
-            {
-                const FluidParticle& pj = m_cpuParticles[idx];
-                XMFLOAT3 rij{ pi.predicted.x - pj.predicted.x, pi.predicted.y - pj.predicted.y, pi.predicted.z - pj.predicted.z };
-                float r = Length(rij);
-                density += mass * Poly6(r, h);
-            }
-            pi.density = std::max(density, restDensity * 0.1f);
-            float Ci = pi.density * invRestDensity - 1.0f;
-
-            XMFLOAT3 gradSum{ 0.0f, 0.0f, 0.0f };
-            float sumGrad2 = 0.0f;
-
-            for (size_t idx : neighbors)
-            {
-                if (idx == i)
-                {
-                    continue;
-                }
-                const FluidParticle& pj = m_cpuParticles[idx];
-                XMFLOAT3 rij{ pi.predicted.x - pj.predicted.x, pi.predicted.y - pj.predicted.y, pi.predicted.z - pj.predicted.z };
-                float r = Length(rij);
-                XMFLOAT3 grad = GradSpiky(rij, r, h);
-                grad.x *= mass * invRestDensity;
-                grad.y *= mass * invRestDensity;
-                grad.z *= mass * invRestDensity;
-                gradSum.x += grad.x;
-                gradSum.y += grad.y;
-                gradSum.z += grad.z;
-                sumGrad2 += grad.x * grad.x + grad.y * grad.y + grad.z * grad.z;
-            }
-
-            sumGrad2 += gradSum.x * gradSum.x + gradSum.y * gradSum.y + gradSum.z * gradSum.z;
-            pi.lambda = -Ci / (sumGrad2 + epsilon);
-        }
-
-        // Δp計算
-        for (size_t i = 0; i < m_cpuParticles.size(); ++i)
-        {
-            FluidParticle& pi = m_cpuParticles[i];
-            neighbors.clear();
-            m_spatialGrid.Query(pi.predicted, h, neighbors);
-
-            XMFLOAT3 delta{ 0.0f, 0.0f, 0.0f };
-            for (size_t idx : neighbors)
-            {
-                if (idx == i)
-                {
-                    continue;
-                }
-                const FluidParticle& pj = m_cpuParticles[idx];
-                XMFLOAT3 rij{ pi.predicted.x - pj.predicted.x, pi.predicted.y - pj.predicted.y, pi.predicted.z - pj.predicted.z };
-                float r = Length(rij);
-                if (r >= h)
-                {
-                    continue;
-                }
-                float w = Poly6(r, h);
-                float corr = 0.0f;
-                float wq = Poly6(deltaQ, h);
-                if (wq > 0.0f)
-                {
-                    corr = sCorrK * std::pow(w / wq, sCorrN);
-                }
-                XMFLOAT3 grad = GradSpiky(rij, r, h);
-                float factor = (pi.lambda + pj.lambda + corr) * mass * invRestDensity;
-                delta.x += grad.x * factor;
-                delta.y += grad.y * factor;
-                delta.z += grad.z * factor;
-            }
-
-            pi.predicted.x += delta.x;
-            pi.predicted.y += delta.y;
-            pi.predicted.z += delta.z;
-
-            pi.collisionMask |= ResolveBounds(pi);
-        }
-    }
-
-    // 速度と位置の更新（XSPHによる安定化込み）
-    for (auto& particle : m_cpuParticles)
-    {
-        XMFLOAT3 delta{ particle.predicted.x - particle.position.x,
-            particle.predicted.y - particle.position.y,
-            particle.predicted.z - particle.position.z };
-        particle.velocity = XMFLOAT3(delta.x / dt, delta.y / dt, delta.z / dt);
-
-        const float preBounceSpeed = XMVectorGetX(XMVector3Length(XMLoadFloat3(&particle.velocity)));
-
-        // XSPH粘性
-        xsphNeighbors.clear();
-        m_spatialGrid.Query(particle.predicted, h, xsphNeighbors);
-        XMFLOAT3 xsph{ 0.0f, 0.0f, 0.0f };
-        for (size_t idx : xsphNeighbors)
-        {
-            if (&particle == &m_cpuParticles[idx])
-            {
-                continue;
-            }
-            const FluidParticle& pj = m_cpuParticles[idx];
-            XMFLOAT3 vij{ pj.velocity.x - particle.velocity.x,
-                pj.velocity.y - particle.velocity.y,
-                pj.velocity.z - particle.velocity.z };
-            XMFLOAT3 rij{ particle.predicted.x - pj.predicted.x,
-                particle.predicted.y - pj.predicted.y,
-                particle.predicted.z - pj.predicted.z };
-            float r = Length(rij);
-            xsph.x += Poly6(r, h) * vij.x;
-            xsph.y += Poly6(r, h) * vij.y;
-            xsph.z += Poly6(r, h) * vij.z;
-        }
-        particle.velocity.x += m_material.xsphC * xsph.x;
-        particle.velocity.y += m_material.xsphC * xsph.y;
-        particle.velocity.z += m_material.xsphC * xsph.z;
-
-        if (particle.collisionMask != 0)
-        {
-            const float restitution = 0.45f; // 境界からの跳ね返り係数
-            XMFLOAT3 normal{ 0.0f, 0.0f, 0.0f };
-
-            if ((particle.collisionMask & kCollisionMinX) && particle.velocity.x < 0.0f)
-            {
-                particle.velocity.x = -particle.velocity.x * restitution;
-                normal.x += 1.0f;
-            }
-            if ((particle.collisionMask & kCollisionMaxX) && particle.velocity.x > 0.0f)
-            {
-                particle.velocity.x = -particle.velocity.x * restitution;
-                normal.x -= 1.0f;
-            }
-            if ((particle.collisionMask & kCollisionMinY) && particle.velocity.y < 0.0f)
-            {
-                particle.velocity.y = -particle.velocity.y * restitution;
-                normal.y += 1.0f;
-            }
-            if ((particle.collisionMask & kCollisionMaxY) && particle.velocity.y > 0.0f)
-            {
-                particle.velocity.y = -particle.velocity.y * restitution;
-                normal.y -= 1.0f;
-            }
-            if ((particle.collisionMask & kCollisionMinZ) && particle.velocity.z < 0.0f)
-            {
-                particle.velocity.z = -particle.velocity.z * restitution;
-                normal.z += 1.0f;
-            }
-            if ((particle.collisionMask & kCollisionMaxZ) && particle.velocity.z > 0.0f)
-            {
-                particle.velocity.z = -particle.velocity.z * restitution;
-                normal.z -= 1.0f;
-            }
-
-            float normalLen = XMVectorGetX(XMVector3Length(XMLoadFloat3(&normal)));
-            if (normalLen > 0.0f && preBounceSpeed > 0.2f)
-            {
-                float invLen = 1.0f / normalLen;
-                normal.x *= invLen;
-                normal.y *= invLen;
-                normal.z *= invLen;
-                FluidCollisionEvent evt{};
-                evt.position = particle.predicted;
-                evt.normal = normal;
-                evt.strength = preBounceSpeed;
-                m_collisionEvents.push_back(evt);
-            }
-
-            particle.collisionMask = 0;
-        }
-
-        particle.position = particle.predicted;
-    }
-
-    m_cpuDirty = true;
-}
-
-UINT FluidSystem::ResolveBounds(FluidParticle& p) const
-{
-    UINT mask = 0;
-    if (p.predicted.x < m_boundsMin.x)
-    {
-        p.predicted.x = m_boundsMin.x;
-        mask |= kCollisionMinX;
-    }
-    else if (p.predicted.x > m_boundsMax.x)
-    {
-        p.predicted.x = m_boundsMax.x;
-        mask |= kCollisionMaxX;
-    }
-
-    if (p.predicted.y < m_boundsMin.y)
-    {
-        p.predicted.y = m_boundsMin.y;
-        mask |= kCollisionMinY;
-    }
-    else if (p.predicted.y > m_boundsMax.y)
-    {
-        p.predicted.y = m_boundsMax.y;
-        mask |= kCollisionMaxY;
-    }
-
-    if (p.predicted.z < m_boundsMin.z)
-    {
-        p.predicted.z = m_boundsMin.z;
-        mask |= kCollisionMinZ;
-    }
-    else if (p.predicted.z > m_boundsMax.z)
-    {
-        p.predicted.z = m_boundsMax.z;
-        mask |= kCollisionMaxZ;
-    }
-    return mask;
-}
-
-bool FluidSystem::Raycast(const XMFLOAT3& origin, const XMFLOAT3& direction, float maxDistance, float radius, XMFLOAT3& hitPosition) const
-{
-    if (m_cpuParticles.empty())
+    m_rootSignature = std::make_unique<RootSignature>();
+    if (!m_rootSignature || !m_rootSignature->IsValid())
     {
         return false;
     }
 
-    XMVECTOR rayOrigin = XMLoadFloat3(&origin);
-    XMVECTOR rayDir = XMVector3Normalize(XMLoadFloat3(&direction));
-    float bestDistance = maxDistance;
-    bool hit = false;
-
-    for (const auto& particle : m_cpuParticles)
+    m_pipelineState = std::make_unique<PipelineState>();
+    if (!m_pipelineState)
     {
-        XMVECTOR pos = XMLoadFloat3(&particle.position);
-        XMVECTOR diff = XMVectorSubtract(pos, rayOrigin);
-        float t = XMVectorGetX(XMVector3Dot(diff, rayDir));
-        if (t < 0.0f || t > bestDistance)
-        {
-            continue;
-        }
-        XMVECTOR closest = XMVectorAdd(rayOrigin, XMVectorScale(rayDir, t));
-        float distanceToRay = XMVectorGetX(XMVector3Length(XMVectorSubtract(pos, closest)));
-        if (distanceToRay <= radius)
-        {
-            bestDistance = t;
-            XMStoreFloat3(&hitPosition, pos);
-            hit = true;
-        }
+        return false;
     }
-
-    return hit;
-}
-
-void FluidSystem::PopCollisionEvents(std::vector<FluidCollisionEvent>& outEvents)
-{
-    if (m_collisionEvents.empty())
-    {
-        outEvents.clear();
-        return;
-    }
-
-    outEvents.insert(outEvents.end(), m_collisionEvents.begin(), m_collisionEvents.end());
-    m_collisionEvents.clear();
-}
-
-void FluidSystem::UploadCPUToGPU(ID3D12GraphicsCommandList* cmd)
-{
-    if (!m_gpuAvailable || !cmd || !m_gpuUpload)
-    {
-        return;
-    }
-
-    if (!m_cpuDirty && !m_gpuDirty)
-    {
-        return;
-    }
-
-    const UINT64 bufferSize = sizeof(GPUFluidParticle) * m_particleCount;
-    if (bufferSize == 0)
-    {
-        return;
-    }
-
-    GPUFluidParticle* mapped = nullptr;
-    if (SUCCEEDED(m_gpuUpload->Map(0, nullptr, reinterpret_cast<void**>(&mapped))) && mapped)
-    {
-        for (UINT i = 0; i < m_particleCount; ++i)
-        {
-            mapped[i].position = m_cpuParticles[i].position;
-            mapped[i].velocity = m_cpuParticles[i].velocity;
-        }
-        m_gpuUpload->Unmap(0, nullptr);
-    }
-
-    for (int i = 0; i < 2; ++i)
-    {
-        auto& buffer = m_gpuParticleBuffers[i];
-        if (!buffer.resource)
-        {
-            continue;
-        }
-        // すでに目的の状態と同じならバリアを張らずにスキップする
-        if (buffer.state != D3D12_RESOURCE_STATE_COPY_DEST)
-        {
-            auto toCopy = CD3DX12_RESOURCE_BARRIER::Transition(buffer.resource.Get(), buffer.state, D3D12_RESOURCE_STATE_COPY_DEST);
-            cmd->ResourceBarrier(1, &toCopy);
-            buffer.state = D3D12_RESOURCE_STATE_COPY_DEST;
-        }
-        cmd->CopyBufferRegion(buffer.resource.Get(), 0, m_gpuUpload.Get(), 0, sizeof(GPUFluidParticle) * m_particleCount);
-        if (buffer.state != D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE)
-        {
-            auto toSRV = CD3DX12_RESOURCE_BARRIER::Transition(buffer.resource.Get(), buffer.state, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
-            cmd->ResourceBarrier(1, &toSRV);
-            buffer.state = D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
-        }
-    }
-
-    m_cpuDirty = false;
-    m_gpuDirty = false;
-}
-
-void FluidSystem::UpdateComputeParams(float dt)
-{
-    if (!m_computeParamsCB)
-    {
-        m_computeParamsCB = std::make_unique<ConstantBuffer>(sizeof(GPUParams));
-    }
-
-    GPUParams* params = m_computeParamsCB->GetPtr<GPUParams>();
-    params->restDensity = m_material.restDensity;
-    params->particleMass = m_material.particleMass;
-    params->viscosity = m_material.viscosity;
-    params->stiffness = m_material.stiffness;
-    params->radius = m_material.smoothingRadius;
-    params->timeStep = dt;
-    params->particleCount = m_particleCount;
-    params->pad0 = 0;
-    params->gridMin = m_boundsMin;
-    params->pad1 = 0.0f;
-    params->gridDim = m_gridDim;
-    params->pad2 = 0;
-
-    if (!m_dummyViewCB)
-    {
-        m_dummyViewCB = std::make_unique<ConstantBuffer>(sizeof(XMFLOAT4X4));
-        XMFLOAT4X4 identity;
-        XMStoreFloat4x4(&identity, XMMatrixIdentity());
-        *m_dummyViewCB->GetPtr<XMFLOAT4X4>() = identity;
-    }
-}
-
-void FluidSystem::StepGPU(ID3D12GraphicsCommandList* cmd, float dt)
-{
-    if (!m_gpuAvailable || !cmd || !m_buildGridPipeline || !m_particlePipeline || !m_clearGridPipeline)
-    {
-        return;
-    }
-
-    const UINT readIndex = m_gpuReadIndex;
-    const UINT writeIndex = 1 - m_gpuReadIndex;
-
-    auto& readBuffer = m_gpuParticleBuffers[readIndex];
-    auto& writeBuffer = m_gpuParticleBuffers[writeIndex];
-
-    if (readBuffer.state != D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE)
-    {
-        auto toSRV = CD3DX12_RESOURCE_BARRIER::Transition(readBuffer.resource.Get(), readBuffer.state, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
-        cmd->ResourceBarrier(1, &toSRV);
-        readBuffer.state = D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
-    }
-
-    if (writeBuffer.state != D3D12_RESOURCE_STATE_UNORDERED_ACCESS)
-    {
-        auto toUAV = CD3DX12_RESOURCE_BARRIER::Transition(writeBuffer.resource.Get(), writeBuffer.state, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
-        cmd->ResourceBarrier(1, &toUAV);
-        writeBuffer.state = D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
-    }
-
-    auto metaToUAV = CD3DX12_RESOURCE_BARRIER::Transition(m_gpuMetaBuffer.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
-    cmd->ResourceBarrier(1, &metaToUAV);
-
-    auto gridCountToUAV = CD3DX12_RESOURCE_BARRIER::Transition(m_gpuGridCount.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
-    cmd->ResourceBarrier(1, &gridCountToUAV);
-
-    auto gridTableToUAV = CD3DX12_RESOURCE_BARRIER::Transition(m_gpuGridTable.Get(), D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
-    cmd->ResourceBarrier(1, &gridTableToUAV);
-
-    ID3D12DescriptorHeap* heaps[] = { g_Engine->CbvSrvUavHeap()->GetHeap() };
-    cmd->SetDescriptorHeaps(1, heaps);
-    cmd->SetComputeRootSignature(m_computeRootSignature.Get());
-
-    // グリッド構築
-    // 毎フレームグリッド情報をゼロ初期化して、古いデータによる不正な粒子カウントを防ぐ
-    cmd->SetPipelineState(m_clearGridPipeline->Get());
-    cmd->SetComputeRootConstantBufferView(0, m_computeParamsCB->GetAddress());
-    cmd->SetComputeRootConstantBufferView(1, m_dummyViewCB->GetAddress());
-    cmd->SetComputeRootDescriptorTable(2, readBuffer.srv->HandleGPU);
-    cmd->SetComputeRootDescriptorTable(3, writeBuffer.uav->HandleGPU);
-    cmd->SetComputeRootDescriptorTable(4, m_gpuMetaUAV->HandleGPU);
-    cmd->SetComputeRootDescriptorTable(5, m_gpuGridCountUAV->HandleGPU);
-    cmd->SetComputeRootDescriptorTable(6, m_gpuGridTableUAV->HandleGPU);
-
-    UINT cellCount = m_gridDim.x * m_gridDim.y * m_gridDim.z;
-    UINT64 tableCount64 = static_cast<UINT64>(cellCount) * static_cast<UINT64>(kMaxParticlesPerCell);
-    UINT clearThreads = static_cast<UINT>(std::min<UINT64>(UINT_MAX, std::max<UINT64>(tableCount64, static_cast<UINT64>(cellCount))));
-    UINT clearGroups = (clearThreads + 255) / 256;
-    cmd->Dispatch(clearGroups, 1, 1);
-
-    cmd->SetPipelineState(m_buildGridPipeline->Get());
-    cmd->SetComputeRootConstantBufferView(0, m_computeParamsCB->GetAddress());
-    cmd->SetComputeRootConstantBufferView(1, m_dummyViewCB->GetAddress());
-    cmd->SetComputeRootDescriptorTable(2, readBuffer.srv->HandleGPU);
-    cmd->SetComputeRootDescriptorTable(3, writeBuffer.uav->HandleGPU);
-    cmd->SetComputeRootDescriptorTable(4, m_gpuMetaUAV->HandleGPU);
-    cmd->SetComputeRootDescriptorTable(5, m_gpuGridCountUAV->HandleGPU);
-    cmd->SetComputeRootDescriptorTable(6, m_gpuGridTableUAV->HandleGPU);
-
-    UINT totalThreads = std::max(m_particleCount, cellCount);
-    UINT groups = (totalThreads + 255) / 256;
-    cmd->Dispatch(groups, 1, 1);
-
-    // 粒子更新
-    cmd->SetPipelineState(m_particlePipeline->Get());
-    cmd->SetComputeRootConstantBufferView(0, m_computeParamsCB->GetAddress());
-    cmd->SetComputeRootConstantBufferView(1, m_dummyViewCB->GetAddress());
-    cmd->SetComputeRootDescriptorTable(2, readBuffer.srv->HandleGPU);
-    cmd->SetComputeRootDescriptorTable(3, writeBuffer.uav->HandleGPU);
-    cmd->SetComputeRootDescriptorTable(4, m_gpuMetaUAV->HandleGPU);
-    cmd->SetComputeRootDescriptorTable(5, m_gpuGridCountUAV->HandleGPU);
-    cmd->SetComputeRootDescriptorTable(6, m_gpuGridTableUAV->HandleGPU);
-
-    UINT groupsParticle = (m_particleCount + 255) / 256;
-    cmd->Dispatch(groupsParticle, 1, 1);
-
-    // 書き込み完了後の状態遷移
-    auto metaToSRV = CD3DX12_RESOURCE_BARRIER::Transition(
-        m_gpuMetaBuffer.Get(),
-        D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
-        D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
-    cmd->ResourceBarrier(1, &metaToSRV);
-    auto gridCountToSRV = CD3DX12_RESOURCE_BARRIER::Transition(
-        m_gpuGridCount.Get(),
-        D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
-        D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
-    cmd->ResourceBarrier(1, &gridCountToSRV);
-    auto gridTableToSRV = CD3DX12_RESOURCE_BARRIER::Transition(
-        m_gpuGridTable.Get(),
-        D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
-        D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
-    cmd->ResourceBarrier(1, &gridTableToSRV);
-
-    // 新しい結果を読み戻し用にコピー
-    if (writeBuffer.state != D3D12_RESOURCE_STATE_COPY_SOURCE)
-    {
-        auto toCopySrc = CD3DX12_RESOURCE_BARRIER::Transition(writeBuffer.resource.Get(), writeBuffer.state, D3D12_RESOURCE_STATE_COPY_SOURCE);
-        cmd->ResourceBarrier(1, &toCopySrc);
-        writeBuffer.state = D3D12_RESOURCE_STATE_COPY_SOURCE;
-    }
-    cmd->CopyBufferRegion(m_gpuReadback.Get(), 0, writeBuffer.resource.Get(), 0, sizeof(GPUFluidParticle) * m_particleCount);
-    if (writeBuffer.state != D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE)
-    {
-        auto backToSRV = CD3DX12_RESOURCE_BARRIER::Transition(writeBuffer.resource.Get(), writeBuffer.state, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
-        cmd->ResourceBarrier(1, &backToSRV);
-        writeBuffer.state = D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
-    }
-
-    m_gpuReadIndex = writeIndex;
-    m_pendingReadback = true;
-}
-
-void FluidSystem::ReadbackGPUToCPU()
-{
-    if (!m_gpuReadback || !m_pendingReadback)
-    {
-        return;
-    }
-
-    // フェンスが完了していなければイベントで待機して安全に読み出す
-    if (m_computeFence && m_lastSubmittedComputeFence != 0)
-    {
-        UINT64 completed = m_computeFence->GetCompletedValue();
-        if (completed < m_lastSubmittedComputeFence && m_computeFenceEvent)
-        {
-            m_computeFence->SetEventOnCompletion(m_lastSubmittedComputeFence, m_computeFenceEvent);
-            WaitForSingleObject(m_computeFenceEvent, INFINITE);
-        }
-    }
-
-    GPUFluidParticle* mapped = nullptr;
-    if (SUCCEEDED(m_gpuReadback->Map(0, nullptr, reinterpret_cast<void**>(&mapped))) && mapped)
-    {
-        for (UINT i = 0; i < m_particleCount; ++i)
-        {
-            m_cpuParticles[i].position = mapped[i].position;
-            m_cpuParticles[i].velocity = mapped[i].velocity;
-            m_cpuParticles[i].predicted = mapped[i].position;
-        }
-        m_gpuReadback->Unmap(0, nullptr);
-    }
-
-    m_pendingReadback = false;
-}
-
-void FluidSystem::UpdateParticleBuffer()
-{
-    if (!m_cpuMetaBuffer)
-    {
-        return;
-    }
-
-    ParticleMetaGPU* mapped = nullptr;
-    if (FAILED(m_cpuMetaBuffer->Map(0, nullptr, reinterpret_cast<void**>(&mapped))) || !mapped)
-    {
-        return;
-    }
-
-    for (UINT i = 0; i < m_particleCount; ++i)
-    {
-        mapped[i].position = m_cpuParticles[i].position;
-        mapped[i].radius = m_material.renderRadius;
-    }
-
-    for (UINT i = m_particleCount; i < m_maxParticles; ++i)
-    {
-        mapped[i].position = XMFLOAT3(0.0f, 0.0f, 0.0f);
-        mapped[i].radius = 0.0f;
-    }
-
-    m_cpuMetaBuffer->Unmap(0, nullptr);
-    m_activeMetaSRV = m_cpuMetaSRV;
-}
-
-
-bool FluidSystem::CreateSSFRResources(ID3D12Device* device, DXGI_FORMAT rtvFormat)
-{
-    if (!device)
+    m_pipelineState->SetInputLayout(ParticleVertex::InputLayout);
+    m_pipelineState->SetRootSignature(m_rootSignature->Get());
+    m_pipelineState->SetVS(L"ParticleVS.cso");
+    m_pipelineState->SetPS(L"ParticlePS.cso");
+    m_pipelineState->SetDepthStencilFormat(DXGI_FORMAT_D32_FLOAT);
+    m_pipelineState->Create(D3D12_PRIMITIVE_TOPOLOGY_TYPE_POINT);
+    if (!m_pipelineState->IsValid())
     {
         return false;
     }
 
-    DestroySSFRResources();
-
-    UINT width = std::max<UINT>(1u, g_Engine->FrameBufferWidth());
-    UINT height = std::max<UINT>(1u, g_Engine->FrameBufferHeight());
-    if (width == 0 || height == 0)
-    {
-        printf("FluidSystem: buckbuffer failed\n");
-        return false;
-    }
-
-    for (UINT i = 0; i < kFrameCount; ++i)
-    {
-        if (!m_cameraCB[i])
-        {
-            m_cameraCB[i] = std::make_unique<ConstantBuffer>(sizeof(SSFRCameraConstants));
-        }
-    }
-
-    if (!m_blurParamsCB)
-    {
-        m_blurParamsCB = std::make_unique<ConstantBuffer>(sizeof(SSFRBlurParams));
-        auto params = m_blurParamsCB->GetPtr<SSFRBlurParams>();
-        params->Sigma = 2.5f;
-        params->DepthK = 1.0f;
-        params->NormalK = 8.0f;
-        params->Padding = 0.0f;
-    }
-
-    UINT64 bufferSize = sizeof(ParticleMetaGPU) * m_maxParticles;
-
-    if (!m_cpuMetaBuffer || m_cpuMetaBuffer->GetDesc().Width < bufferSize)
-    {
-        m_cpuMetaBuffer.Reset();
-        auto cpuHeap = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
-        auto cpuDesc = CD3DX12_RESOURCE_DESC::Buffer(bufferSize);
-        HRESULT hr = device->CreateCommittedResource(&cpuHeap, D3D12_HEAP_FLAG_NONE, &cpuDesc,
-            D3D12_RESOURCE_STATE_GENERIC_READ, nullptr,
-            IID_PPV_ARGS(m_cpuMetaBuffer.ReleaseAndGetAddressOf()));
-        if (FAILED(hr))
-        {
-            printf("FluidSystem: CPUメタデータバッファの生成に失敗しました (0x%08X)\n", hr);
-            return false;
-        }
-
-        if (!m_cpuMetaSRV)
-        {
-            m_cpuMetaSRV = g_Engine->CbvSrvUavHeap()->RegisterBuffer(m_cpuMetaBuffer.Get(), m_maxParticles, sizeof(ParticleMetaGPU));
-        }
-        else
-        {
-            D3D12_SHADER_RESOURCE_VIEW_DESC desc{};
-            desc.Format = DXGI_FORMAT_UNKNOWN;
-            desc.ViewDimension = D3D12_SRV_DIMENSION_BUFFER;
-            desc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-            desc.Buffer.NumElements = m_maxParticles;
-            desc.Buffer.StructureByteStride = sizeof(ParticleMetaGPU);
-            g_Engine->Device()->CreateShaderResourceView(m_cpuMetaBuffer.Get(), &desc, m_cpuMetaSRV->HandleCPU);
-        }
-    }
-
-    auto gpuHeap = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
-    auto gpuDesc = CD3DX12_RESOURCE_DESC::Buffer(bufferSize, D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
-    if (!m_gpuMetaBuffer || m_gpuMetaBuffer->GetDesc().Width < bufferSize)
-    {
-        m_gpuMetaBuffer.Reset();
-        HRESULT hr = device->CreateCommittedResource(&gpuHeap, D3D12_HEAP_FLAG_NONE, &gpuDesc,
-            D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, nullptr,
-            IID_PPV_ARGS(m_gpuMetaBuffer.ReleaseAndGetAddressOf()));
-        if (FAILED(hr))
-        {
-            printf("FluidSystem: GPUメタデータバッファの生成に失敗しました (0x%08X)\n", hr);
-            return false;
-        }
-    }
-
-    if (!m_gpuMetaSRV)
-    {
-        m_gpuMetaSRV = g_Engine->CbvSrvUavHeap()->RegisterBuffer(m_gpuMetaBuffer.Get(), m_maxParticles, sizeof(ParticleMetaGPU));
-    }
-    else
-    {
-        D3D12_SHADER_RESOURCE_VIEW_DESC desc{};
-        desc.Format = DXGI_FORMAT_UNKNOWN;
-        desc.ViewDimension = D3D12_SRV_DIMENSION_BUFFER;
-        desc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-        desc.Buffer.NumElements = m_maxParticles;
-        desc.Buffer.StructureByteStride = sizeof(ParticleMetaGPU);
-        g_Engine->Device()->CreateShaderResourceView(m_gpuMetaBuffer.Get(), &desc, m_gpuMetaSRV->HandleCPU);
-    }
-
-    if (!m_gpuMetaUAV)
-    {
-        m_gpuMetaUAV = g_Engine->CbvSrvUavHeap()->RegisterBufferUAV(m_gpuMetaBuffer.Get(), m_maxParticles, sizeof(ParticleMetaGPU));
-    }
-    else
-    {
-        D3D12_UNORDERED_ACCESS_VIEW_DESC desc{};
-        desc.Format = DXGI_FORMAT_UNKNOWN;
-        desc.ViewDimension = D3D12_UAV_DIMENSION_BUFFER;
-        desc.Buffer.NumElements = m_maxParticles;
-        desc.Buffer.StructureByteStride = sizeof(ParticleMetaGPU);
-        g_Engine->Device()->CreateUnorderedAccessView(m_gpuMetaBuffer.Get(), nullptr, &desc, m_gpuMetaUAV->HandleCPU);
-    }
-
-    m_activeMetaSRV = m_cpuMetaSRV;
-
-    if (!m_ssfrRtvHeap)
-    {
-        D3D12_DESCRIPTOR_HEAP_DESC heapDesc{};
-        heapDesc.NumDescriptors = 3;
-        heapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-        heapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        HRESULT hr = device->CreateDescriptorHeap(&heapDesc, IID_PPV_ARGS(m_ssfrRtvHeap.ReleaseAndGetAddressOf()));
-        if (FAILED(hr))
-        {
-            printf("FluidSystem: SSFR用RTVヒープの生成に失敗しました (0x%08X)\n", hr);
-            return false;
-        }
-        m_ssfrRtvDescriptorSize = device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-    }
-
-    if (!m_ssfrCpuUavHeap)
-    {
-        D3D12_DESCRIPTOR_HEAP_DESC heapDesc{};
-        heapDesc.NumDescriptors = 3;
-        heapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-        heapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-        HRESULT hr = device->CreateDescriptorHeap(&heapDesc, IID_PPV_ARGS(m_ssfrCpuUavHeap.ReleaseAndGetAddressOf()));
-        if (FAILED(hr))
-        {
-            printf("FluidSystem: SSFR用CPU UAVヒープの生成に失敗しました (0x%08X)\n", hr);
-            return false;
-        }
-        m_ssfrCpuUavDescriptorSize = device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
-
-        // UAVのクリアではCPU可視ディスクリプタが必須なため、ここでオフラインハンドルを確保する
-        auto cpuHandle = m_ssfrCpuUavHeap->GetCPUDescriptorHandleForHeapStart();
-        m_particleDepthUavCpuHandle = cpuHandle;
-        cpuHandle.ptr += m_ssfrCpuUavDescriptorSize;
-        m_smoothedDepthUavCpuHandle = cpuHandle;
-    }
-
-    CD3DX12_HEAP_PROPERTIES defaultHeap(D3D12_HEAP_TYPE_DEFAULT);
-
-    auto rtvHandle = m_ssfrRtvHeap->GetCPUDescriptorHandleForHeapStart();
-    m_particleDepthRTV = rtvHandle;
-    rtvHandle.ptr += m_ssfrRtvDescriptorSize;
-    m_smoothedDepthRTV = rtvHandle;
-    rtvHandle.ptr += m_ssfrRtvDescriptorSize;
-    m_thicknessRTV = rtvHandle;
-
-    auto createTexture = [&](DXGI_FORMAT format,
-        const wchar_t* name,
-        std::unique_ptr<Texture2D>& texture,
-        DescriptorHandle*& srvHandle,
-        DescriptorHandle*& uavHandle,
-        D3D12_CPU_DESCRIPTOR_HANDLE rtv,
-        D3D12_CPU_DESCRIPTOR_HANDLE uavCpuHandle,
-        D3D12_RESOURCE_STATES& state,
-        bool createRTV)
-    {
-        D3D12_RESOURCE_FLAGS flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
-        if (createRTV)
-        {
-            flags |= D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET;
-        }
-
-        CD3DX12_RESOURCE_DESC desc = CD3DX12_RESOURCE_DESC::Tex2D(format, width, height, 1, 1);
-        desc.Flags = flags;
-
-        D3D12_CLEAR_VALUE clear{};
-        clear.Format = format;
-        clear.Color[0] = 0.0f;
-        clear.Color[1] = 0.0f;
-        clear.Color[2] = 0.0f;
-        clear.Color[3] = (format == DXGI_FORMAT_R32_FLOAT) ? 1.0f : 0.0f;
-
-        Microsoft::WRL::ComPtr<ID3D12Resource> resource;
-        HRESULT hr = device->CreateCommittedResource(
-            &defaultHeap,
-            D3D12_HEAP_FLAG_NONE,
-            &desc,
-            D3D12_RESOURCE_STATE_COMMON,
-            createRTV ? &clear : nullptr,
-            IID_PPV_ARGS(resource.ReleaseAndGetAddressOf()));
-        if (FAILED(hr))
-        {
-            printf("FluidSystem: テクスチャ %ls の生成に失敗しました (0x%08X)\n", name, hr);
-            return false;
-        }
-        resource->SetName(name);
-
-        texture = std::unique_ptr<Texture2D>(new Texture2D(resource.Get()));
-
-        D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = texture->ViewDesc();
-        if (!srvHandle)
-        {
-            srvHandle = g_Engine->CbvSrvUavHeap()->Register(texture.get());
-        }
-        else
-        {
-            g_Engine->Device()->CreateShaderResourceView(resource.Get(), &srvDesc, srvHandle->HandleCPU);
-        }
-        if (!srvHandle)
-        {
-            printf("FluidSystem: %ls のSRV登録に失敗しました\n", name);
-            return false;
-        }
-
-        D3D12_UNORDERED_ACCESS_VIEW_DESC uavDesc{};
-        uavDesc.Format = format;
-        uavDesc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE2D;
-        uavDesc.Texture2D.MipSlice = 0;
-        uavDesc.Texture2D.PlaneSlice = 0;
-
-        if (!uavHandle)
-        {
-            uavHandle = g_Engine->CbvSrvUavHeap()->RegisterTextureUAV(resource.Get(), format);
-        }
-        if (!uavHandle)
-        {
-            printf("FluidSystem: %ls のUAV登録に失敗しました\n", name);
-            return false;
-        }
-        g_Engine->Device()->CreateUnorderedAccessView(resource.Get(), nullptr, &uavDesc, uavHandle->HandleCPU);
-
-        if (uavCpuHandle.ptr != 0)
-        {
-            g_Engine->Device()->CreateUnorderedAccessView(resource.Get(), nullptr, &uavDesc, uavCpuHandle);
-        }
-
-        if (createRTV)
-        {
-            device->CreateRenderTargetView(resource.Get(), nullptr, rtv);
-        }
-
-        state = D3D12_RESOURCE_STATE_COMMON;
-        return true;
-    };
-
-    if (!createTexture(DXGI_FORMAT_R32_FLOAT, L"FluidParticleDepth", m_particleDepthTexture, m_particleDepthSRV, m_particleDepthUAV, m_particleDepthRTV, m_particleDepthUavCpuHandle, m_particleDepthState, true))
+    size_t bufferSize = sizeof(ParticleVertex) * m_renderVertices.size();
+    m_vertexBuffer = std::make_unique<VertexBuffer>(bufferSize, sizeof(ParticleVertex), m_renderVertices.data());
+    if (!m_vertexBuffer || !m_vertexBuffer->IsValid())
     {
         return false;
     }
 
-    if (!createTexture(DXGI_FORMAT_R32_FLOAT, L"FluidSmoothedDepth", m_smoothedDepthTexture, m_smoothedDepthSRV, m_smoothedDepthUAV, m_smoothedDepthRTV, m_smoothedDepthUavCpuHandle, m_smoothedDepthState, true))
+    for (auto& cb : m_constantBuffers)
     {
-        return false;
-    }
-
-    if (!createTexture(DXGI_FORMAT_R8G8B8A8_UNORM, L"FluidNormal", m_normalTexture, m_normalSRV, m_normalUAV, {}, {}, m_normalState, false))
-    {
-        return false;
-    }
-
-    if (!createTexture(DXGI_FORMAT_R16_FLOAT, L"FluidThickness", m_thicknessTexture, m_thicknessSRV, m_thicknessUAV, m_thicknessRTV, {}, m_thicknessState, true))
-    {
-        return false;
-    }
-
-    // シーンカラーを参照するためのコピー先テクスチャとSRVを用意
-    {
-        bool needCreate = !m_sceneColorCopy;
-        if (m_sceneColorCopy)
+        cb = std::make_unique<ConstantBuffer>(sizeof(FluidConstant));
+        if (!cb || !cb->IsValid())
         {
-            auto desc = m_sceneColorCopy->GetDesc();
-            needCreate = desc.Width != width || desc.Height != height;
-        }
-
-        if (needCreate)
-        {
-            m_sceneColorCopy.Reset();
-            auto colorDesc = CD3DX12_RESOURCE_DESC::Tex2D(rtvFormat, width, height, 1, 1);
-            HRESULT hr = device->CreateCommittedResource(
-                &gpuHeap,
-                D3D12_HEAP_FLAG_NONE,
-                &colorDesc,
-                D3D12_RESOURCE_STATE_COPY_DEST,
-                nullptr,
-                IID_PPV_ARGS(m_sceneColorCopy.ReleaseAndGetAddressOf()));
-            if (FAILED(hr))
-            {
-                printf("FluidSystem: シーンカラーコピー用テクスチャの生成に失敗しました (0x%08X)\n", hr);
-                return false;
-            }
-            m_sceneColorCopyState = D3D12_RESOURCE_STATE_COPY_DEST;
-        }
-
-        D3D12_SHADER_RESOURCE_VIEW_DESC sceneColorDesc{};
-        sceneColorDesc.Format = rtvFormat;
-        sceneColorDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-        sceneColorDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
-        sceneColorDesc.Texture2D.MipLevels = 1;
-        if (!m_sceneColorSRV)
-        {
-            m_sceneColorSRV = g_Engine->CbvSrvUavHeap()->Register(m_sceneColorCopy.Get(), sceneColorDesc);
-        }
-        else
-        {
-            g_Engine->Device()->CreateShaderResourceView(m_sceneColorCopy.Get(), &sceneColorDesc, m_sceneColorSRV->HandleCPU);
-        }
-        if (!m_sceneColorSRV)
-        {
-            printf("FluidSystem: シーンカラーSRVの登録に失敗しました\n");
-            return false;
-        }
-    }
-
-    // 深度バッファを参照するためのSRVを作成
-    if (ID3D12Resource* depthBuffer = g_Engine->DepthStencilBuffer())
-    {
-        D3D12_SHADER_RESOURCE_VIEW_DESC depthDesc{};
-        depthDesc.Format = DXGI_FORMAT_R32_FLOAT;
-        depthDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-        depthDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
-        depthDesc.Texture2D.MipLevels = 1;
-        if (!m_sceneDepthSRV)
-        {
-            m_sceneDepthSRV = g_Engine->CbvSrvUavHeap()->Register(depthBuffer, depthDesc);
-        }
-        else
-        {
-            g_Engine->Device()->CreateShaderResourceView(depthBuffer, &depthDesc, m_sceneDepthSRV->HandleCPU);
-        }
-        if (!m_sceneDepthSRV)
-        {
-            printf("FluidSystem: シーン深度SRVの登録に失敗しました\n");
-            return false;
-        }
-        m_sceneDepthState = D3D12_RESOURCE_STATE_DEPTH_WRITE;
-    }
-
-    // 粒子描画ルートシグネチャ
-    {
-        CD3DX12_DESCRIPTOR_RANGE srvRange;
-        // 頂点シェーダーで StructuredBuffer<ParticleData> (t0) を読むための SRV テーブル
-        srvRange.Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0);
-
-        CD3DX12_DESCRIPTOR_RANGE uavRanges[3];
-        // ピクセルシェーダーの RTV0 と競合しないよう、UAV はレジスタ u1 以降へ配置
-        uavRanges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_UAV, 1, 1);
-        uavRanges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_UAV, 1, 2);
-        uavRanges[2].Init(D3D12_DESCRIPTOR_RANGE_TYPE_UAV, 1, 3);
-
-        CD3DX12_ROOT_PARAMETER params[5];
-        params[0].InitAsConstantBufferView(0, 0, D3D12_SHADER_VISIBILITY_ALL);
-        params[1].InitAsDescriptorTable(1, &srvRange, D3D12_SHADER_VISIBILITY_VERTEX);
-        params[2].InitAsDescriptorTable(1, &uavRanges[0], D3D12_SHADER_VISIBILITY_PIXEL);
-        params[3].InitAsDescriptorTable(1, &uavRanges[1], D3D12_SHADER_VISIBILITY_PIXEL);
-        params[4].InitAsDescriptorTable(1, &uavRanges[2], D3D12_SHADER_VISIBILITY_PIXEL);
-
-        CD3DX12_ROOT_SIGNATURE_DESC desc(_countof(params), params, 0, nullptr,
-            D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_HULL_SHADER_ROOT_ACCESS |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_DOMAIN_SHADER_ROOT_ACCESS |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_GEOMETRY_SHADER_ROOT_ACCESS);
-
-        Microsoft::WRL::ComPtr<ID3DBlob> blob, error;
-        HRESULT hr = D3D12SerializeRootSignature(&desc, D3D_ROOT_SIGNATURE_VERSION_1, &blob, &error);
-        if (FAILED(hr))
-        {
-            if (error)
-            {
-                printf("FluidSystem: 粒子用ルートシグネチャ生成失敗 -> %s", static_cast<const char*>(error->GetBufferPointer()));
-            }
-            return false;
-        }
-        hr = device->CreateRootSignature(0, blob->GetBufferPointer(), blob->GetBufferSize(), IID_PPV_ARGS(m_particleRootSignature.ReleaseAndGetAddressOf()));
-        if (FAILED(hr))
-        {
-            printf("FluidSystem: 粒子用ルートシグネチャ作成に失敗しました (0x%08X)", hr);
-            return false;
-        }
-
-        Microsoft::WRL::ComPtr<ID3DBlob> vs, ps;
-        if (!LoadOrCompileShader(L"SSFRParticleVS.hlsl", "main", "vs_5_0", vs))
-        {
-            return false;
-        }
-        if (!LoadOrCompileShader(L"SSFRParticlePS.hlsl", "main", "ps_5_0", ps))
-        {
-            return false;
-        }
-
-        D3D12_GRAPHICS_PIPELINE_STATE_DESC pso{};
-        pso.pRootSignature = m_particleRootSignature.Get();
-        pso.VS = { vs->GetBufferPointer(), vs->GetBufferSize() };
-        pso.PS = { ps->GetBufferPointer(), ps->GetBufferSize() };
-        pso.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-        pso.SampleMask = UINT_MAX;
-        pso.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-        pso.RasterizerState.CullMode = D3D12_CULL_MODE_NONE;
-        pso.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
-        pso.DepthStencilState.DepthEnable = FALSE;
-        pso.DepthStencilState.StencilEnable = FALSE;
-        pso.InputLayout = { nullptr, 0 };
-        pso.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        pso.NumRenderTargets = 1;
-        pso.RTVFormats[0] = rtvFormat;
-        // 深度を使用しないPSOなので、DSV形式はUNKNOWNにして空のDSVバインドを許可する
-        pso.DSVFormat = DXGI_FORMAT_UNKNOWN;
-        pso.SampleDesc.Count = 1;
-        pso.SampleDesc.Quality = 0;
-
-        hr = device->CreateGraphicsPipelineState(&pso, IID_PPV_ARGS(m_particlePipelineState.ReleaseAndGetAddressOf()));
-        if (FAILED(hr))
-        {
-            printf("FluidSystem: 粒子描画PSOの生成に失敗しました (0x%08X)", hr);
-            return false;
-        }
-    }
-
-    // バイラテラルブラー
-    {
-        CD3DX12_DESCRIPTOR_RANGE srvRanges[2];
-        srvRanges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0);
-        srvRanges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 1);
-        CD3DX12_DESCRIPTOR_RANGE uavRange(D3D12_DESCRIPTOR_RANGE_TYPE_UAV, 1, 0);
-        CD3DX12_ROOT_PARAMETER params[5];
-        params[0].InitAsDescriptorTable(1, &srvRanges[0]);
-        params[1].InitAsDescriptorTable(1, &srvRanges[1]);
-        params[2].InitAsDescriptorTable(1, &uavRange);
-        params[3].InitAsConstantBufferView(0);
-        params[4].InitAsConstantBufferView(1);
-
-        CD3DX12_ROOT_SIGNATURE_DESC desc(_countof(params), params, 0, nullptr,
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_VERTEX_SHADER_ROOT_ACCESS |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_HULL_SHADER_ROOT_ACCESS |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_DOMAIN_SHADER_ROOT_ACCESS |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_GEOMETRY_SHADER_ROOT_ACCESS |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_PIXEL_SHADER_ROOT_ACCESS);
-
-        Microsoft::WRL::ComPtr<ID3DBlob> blob, error;
-        HRESULT hr = D3D12SerializeRootSignature(&desc, D3D_ROOT_SIGNATURE_VERSION_1, &blob, &error);
-        if (FAILED(hr))
-        {
-            if (error)
-            {
-                printf("FluidSystem: ブラー用ルートシグネチャ生成失敗 -> %s", static_cast<const char*>(error->GetBufferPointer()));
-            }
-            return false;
-        }
-        hr = device->CreateRootSignature(0, blob->GetBufferPointer(), blob->GetBufferSize(), IID_PPV_ARGS(m_blurRootSignature.ReleaseAndGetAddressOf()));
-        if (FAILED(hr))
-        {
-            printf("FluidSystem: ブラー用ルートシグネチャ作成に失敗しました (0x%08X)", hr);
-            return false;
-        }
-
-        Microsoft::WRL::ComPtr<ID3DBlob> cs;
-        if (!LoadOrCompileShader(L"SSFRBilateralCS.hlsl", "main", "cs_5_0", cs))
-        {
-            return false;
-        }
-
-        D3D12_COMPUTE_PIPELINE_STATE_DESC pso{};
-        pso.pRootSignature = m_blurRootSignature.Get();
-        pso.CS = { cs->GetBufferPointer(), cs->GetBufferSize() };
-        HRESULT hr2 = device->CreateComputePipelineState(&pso, IID_PPV_ARGS(m_blurPipelineState.ReleaseAndGetAddressOf()));
-        if (FAILED(hr2))
-        {
-            printf("FluidSystem: ブラー用PSO作成に失敗しました (0x%08X)", hr2);
-            return false;
-        }
-    }
-
-    // 法線生成
-    {
-        CD3DX12_DESCRIPTOR_RANGE srvRange(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0);
-        CD3DX12_DESCRIPTOR_RANGE uavRange(D3D12_DESCRIPTOR_RANGE_TYPE_UAV, 1, 0);
-        CD3DX12_ROOT_PARAMETER params[3];
-        params[0].InitAsDescriptorTable(1, &srvRange);
-        params[1].InitAsDescriptorTable(1, &uavRange);
-        params[2].InitAsConstantBufferView(0);
-
-        CD3DX12_ROOT_SIGNATURE_DESC desc(_countof(params), params, 0, nullptr,
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_VERTEX_SHADER_ROOT_ACCESS |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_HULL_SHADER_ROOT_ACCESS |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_DOMAIN_SHADER_ROOT_ACCESS |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_GEOMETRY_SHADER_ROOT_ACCESS |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_PIXEL_SHADER_ROOT_ACCESS);
-
-        Microsoft::WRL::ComPtr<ID3DBlob> blob, error;
-        HRESULT hr = D3D12SerializeRootSignature(&desc, D3D_ROOT_SIGNATURE_VERSION_1, &blob, &error);
-        if (FAILED(hr))
-        {
-            if (error)
-            {
-                printf("FluidSystem: 法線CSルートシグネチャ生成失敗 -> %s", static_cast<const char*>(error->GetBufferPointer()));
-            }
-            return false;
-        }
-        hr = device->CreateRootSignature(0, blob->GetBufferPointer(), blob->GetBufferSize(), IID_PPV_ARGS(m_normalRootSignature.ReleaseAndGetAddressOf()));
-        if (FAILED(hr))
-        {
-            printf("FluidSystem: 法線CSルートシグネチャ作成に失敗しました (0x%08X)", hr);
-            return false;
-        }
-
-        Microsoft::WRL::ComPtr<ID3DBlob> cs;
-        if (!LoadOrCompileShader(L"SSFRNormalCS.hlsl", "main", "cs_5_0", cs))
-        {
-            return false;
-        }
-
-        D3D12_COMPUTE_PIPELINE_STATE_DESC pso{};
-        pso.pRootSignature = m_normalRootSignature.Get();
-        pso.CS = { cs->GetBufferPointer(), cs->GetBufferSize() };
-        HRESULT hr2 = device->CreateComputePipelineState(&pso, IID_PPV_ARGS(m_normalPipelineState.ReleaseAndGetAddressOf()));
-        if (FAILED(hr2))
-        {
-            printf("FluidSystem: 法線生成PSO作成に失敗しました (0x%08X)", hr2);
-            return false;
-        }
-    }
-
-    // 合成
-    {
-        CD3DX12_DESCRIPTOR_RANGE srvRanges[5];
-        srvRanges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0);
-        srvRanges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 1);
-        srvRanges[2].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 2);
-        srvRanges[3].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 3);
-        srvRanges[4].Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 4);
-        CD3DX12_ROOT_PARAMETER params[6];
-        params[0].InitAsDescriptorTable(1, &srvRanges[0], D3D12_SHADER_VISIBILITY_PIXEL);
-        params[1].InitAsDescriptorTable(1, &srvRanges[1], D3D12_SHADER_VISIBILITY_PIXEL);
-        params[2].InitAsDescriptorTable(1, &srvRanges[2], D3D12_SHADER_VISIBILITY_PIXEL);
-        params[3].InitAsDescriptorTable(1, &srvRanges[3], D3D12_SHADER_VISIBILITY_PIXEL);
-        params[4].InitAsDescriptorTable(1, &srvRanges[4], D3D12_SHADER_VISIBILITY_PIXEL);
-        params[5].InitAsConstantBufferView(0, 0, D3D12_SHADER_VISIBILITY_PIXEL);
-
-        CD3DX12_STATIC_SAMPLER_DESC sampler(0);
-        sampler.Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
-        sampler.AddressU = sampler.AddressV = sampler.AddressW = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
-
-        CD3DX12_ROOT_SIGNATURE_DESC desc(_countof(params), params, 1, &sampler,
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_VERTEX_SHADER_ROOT_ACCESS |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_HULL_SHADER_ROOT_ACCESS |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_DOMAIN_SHADER_ROOT_ACCESS |
-            D3D12_ROOT_SIGNATURE_FLAG_DENY_GEOMETRY_SHADER_ROOT_ACCESS);
-
-        Microsoft::WRL::ComPtr<ID3DBlob> blob, error;
-        HRESULT hr = D3D12SerializeRootSignature(&desc, D3D_ROOT_SIGNATURE_VERSION_1, &blob, &error);
-        if (FAILED(hr))
-        {
-            if (error)
-            {
-                printf("FluidSystem: 合成ルートシグネチャ生成失敗 -> %s", static_cast<const char*>(error->GetBufferPointer()));
-            }
-            return false;
-        }
-        hr = device->CreateRootSignature(0, blob->GetBufferPointer(), blob->GetBufferSize(), IID_PPV_ARGS(m_compositeRootSignature.ReleaseAndGetAddressOf()));
-        if (FAILED(hr))
-        {
-            printf("FluidSystem: 合成ルートシグネチャ作成に失敗しました (0x%08X)", hr);
-            return false;
-        }
-
-        Microsoft::WRL::ComPtr<ID3DBlob> vs, ps;
-        if (!LoadOrCompileShader(L"FullscreenVS.hlsl", "main", "vs_5_0", vs))
-        {
-            return false;
-        }
-        if (!LoadOrCompileShader(L"SSFRCompositePS.hlsl", "main", "ps_5_0", ps))
-        {
-            return false;
-        }
-
-        D3D12_GRAPHICS_PIPELINE_STATE_DESC pso{};
-        pso.pRootSignature = m_compositeRootSignature.Get();
-        pso.VS = { vs->GetBufferPointer(), vs->GetBufferSize() };
-        pso.PS = { ps->GetBufferPointer(), ps->GetBufferSize() };
-        pso.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
-        pso.SampleMask = UINT_MAX;
-        pso.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
-        pso.RasterizerState.CullMode = D3D12_CULL_MODE_NONE;
-        pso.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
-        pso.DepthStencilState.DepthEnable = FALSE;
-        pso.DepthStencilState.StencilEnable = FALSE;
-        pso.InputLayout = { nullptr, 0 };
-        pso.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
-        pso.NumRenderTargets = 1;
-        pso.RTVFormats[0] = rtvFormat;
-        pso.SampleDesc.Count = 1;
-        pso.SampleDesc.Quality = 0;
-
-        HRESULT hr2 = device->CreateGraphicsPipelineState(&pso, IID_PPV_ARGS(m_compositePipelineState.ReleaseAndGetAddressOf()));
-        if (FAILED(hr2))
-        {
-            printf("FluidSystem: 合成PSOの生成に失敗しました (0x%08X)", hr2);
             return false;
         }
     }
@@ -2000,546 +67,212 @@ bool FluidSystem::CreateSSFRResources(ID3D12Device* device, DXGI_FORMAT rtvForma
     return true;
 }
 
-void FluidSystem::DestroySSFRResources()
+void FluidSystem::InitializeParticles(UINT particleCount)
 {
-    m_particleDepthTexture.reset();
-    m_smoothedDepthTexture.reset();
-    m_normalTexture.reset();
-    m_thicknessTexture.reset();
-    m_particleDepthState = D3D12_RESOURCE_STATE_COMMON;
-    m_smoothedDepthState = D3D12_RESOURCE_STATE_COMMON;
-    m_normalState = D3D12_RESOURCE_STATE_COMMON;
-    m_thicknessState = D3D12_RESOURCE_STATE_COMMON;
-    m_sceneColorCopy.Reset();
-    m_sceneColorCopyState = D3D12_RESOURCE_STATE_COMMON;
-    m_sceneDepthState = D3D12_RESOURCE_STATE_DEPTH_WRITE;
-    m_sceneColorSRV = nullptr;
-    m_sceneDepthSRV = nullptr;
-    m_ssfrCpuUavHeap.Reset();
-    m_ssfrCpuUavDescriptorSize = 0;
-    m_particleDepthUavCpuHandle = {};
-    m_smoothedDepthUavCpuHandle = {};
+    m_particles.clear();
+    m_particles.resize(particleCount);
+    m_renderVertices.clear();
+    m_renderVertices.resize(particleCount);
 
-    m_particleRootSignature.Reset();
-    m_particlePipelineState.Reset();
-    m_blurRootSignature.Reset();
-    m_blurPipelineState.Reset();
-    m_normalRootSignature.Reset();
-    m_normalPipelineState.Reset();
-    m_compositeRootSignature.Reset();
-    m_compositePipelineState.Reset();
-}
+    // 初期配置は境界内に均等配置し、軽い乱数でばらけさせる
+    std::mt19937 rng{ 12345u };
+    std::uniform_real_distribution<float> jitter(-0.02f, 0.02f);
 
-void FluidSystem::CreateGPUResources(ID3D12Device* device)
-{
-    if (!device)
+    const float startX = m_bounds.min.x + m_particleRadius;
+    const float startY = m_bounds.min.y + m_particleRadius;
+    const float startZ = m_bounds.min.z + m_particleRadius;
+    const float maxX = m_bounds.max.x - m_particleRadius;
+    const float maxY = m_bounds.max.y - m_particleRadius;
+    const float maxZ = m_bounds.max.z - m_particleRadius;
+
+    const UINT perRow = static_cast<UINT>(std::cbrt(static_cast<float>(particleCount))) + 1;
+    const float spacing = std::max(m_particleRadius * 2.2f, 0.05f);
+
+    UINT index = 0;
+    for (UINT y = 0; y < perRow && index < particleCount; ++y)
     {
-        return;
-    }
-
-    UpdateGridSettings();
-
-    UINT particleStride = sizeof(GPUFluidParticle);
-    UINT metaStride = sizeof(ParticleMetaGPU);
-    UINT particleBufferSize = particleStride * m_maxParticles;
-    UINT metaBufferSize = metaStride * m_maxParticles;
-    UINT cellCount = std::max<UINT>(1u, m_gridDim.x * m_gridDim.y * m_gridDim.z);
-
-    auto defaultHeap = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
-
-    for (int i = 0; i < 2; ++i)
-    {
-        auto desc = CD3DX12_RESOURCE_DESC::Buffer(particleBufferSize, D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
-        HRESULT hr = device->CreateCommittedResource(&defaultHeap, D3D12_HEAP_FLAG_NONE, &desc, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, nullptr,
-            IID_PPV_ARGS(m_gpuParticleBuffers[i].resource.ReleaseAndGetAddressOf()));
-        if (FAILED(hr))
+        for (UINT z = 0; z < perRow && index < particleCount; ++z)
         {
-            printf("FluidSystem 6 : GPU粒子バッファ生成に失敗しました (%d)\n", i);
-            m_gpuAvailable = false;
-            return;
-        }
-        m_gpuParticleBuffers[i].state = D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
-
-        if (!m_gpuParticleBuffers[i].srv)
-        {
-            m_gpuParticleBuffers[i].srv = g_Engine->CbvSrvUavHeap()->RegisterBuffer(m_gpuParticleBuffers[i].resource.Get(), m_maxParticles, particleStride);
-        }
-        else
-        {
-            D3D12_SHADER_RESOURCE_VIEW_DESC descSrv{};
-            descSrv.Format = DXGI_FORMAT_UNKNOWN;
-            descSrv.ViewDimension = D3D12_SRV_DIMENSION_BUFFER;
-            descSrv.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-            descSrv.Buffer.NumElements = m_maxParticles;
-            descSrv.Buffer.StructureByteStride = particleStride;
-            g_Engine->Device()->CreateShaderResourceView(m_gpuParticleBuffers[i].resource.Get(), &descSrv, m_gpuParticleBuffers[i].srv->HandleCPU);
-        }
-        if (!m_gpuParticleBuffers[i].srv)
-        {
-            printf("FluidSystem 7 : GPU粒子SRVの登録に失敗しました (%d)\n", i);
-            m_gpuAvailable = false;
-            return;
-        }
-
-        if (!m_gpuParticleBuffers[i].uav)
-        {
-            m_gpuParticleBuffers[i].uav = g_Engine->CbvSrvUavHeap()->RegisterBufferUAV(m_gpuParticleBuffers[i].resource.Get(), m_maxParticles, particleStride);
-        }
-        else
-        {
-            D3D12_UNORDERED_ACCESS_VIEW_DESC descUAV{};
-            descUAV.Format = DXGI_FORMAT_UNKNOWN;
-            descUAV.ViewDimension = D3D12_UAV_DIMENSION_BUFFER;
-            descUAV.Buffer.NumElements = m_maxParticles;
-            descUAV.Buffer.StructureByteStride = particleStride;
-            g_Engine->Device()->CreateUnorderedAccessView(m_gpuParticleBuffers[i].resource.Get(), nullptr, &descUAV, m_gpuParticleBuffers[i].uav->HandleCPU);
-        }
-        if (!m_gpuParticleBuffers[i].uav)
-        {
-            printf("FluidSystem 8 : GPU粒子UAVの登録に失敗しました (%d)\n", i);
-            m_gpuAvailable = false;
-            return;
-        }
-    }
-
-    // グリッドバッファ
-    auto gridDesc = CD3DX12_RESOURCE_DESC::Buffer(sizeof(UINT) * cellCount, D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
-    HRESULT hrGrid = device->CreateCommittedResource(&defaultHeap, D3D12_HEAP_FLAG_NONE, &gridDesc, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, nullptr,
-        IID_PPV_ARGS(m_gpuGridCount.ReleaseAndGetAddressOf()));
-    if (FAILED(hrGrid))
-    {
-        printf("FluidSystem 9 : グリッドカウントバッファ生成に失敗しました\n");
-        m_gpuAvailable = false;
-        return;
-    }
-    if (!m_gpuGridCountSRV)
-    {
-        m_gpuGridCountSRV = g_Engine->CbvSrvUavHeap()->RegisterBuffer(m_gpuGridCount.Get(), cellCount, sizeof(UINT));
-    }
-    else
-    {
-        D3D12_SHADER_RESOURCE_VIEW_DESC desc{};
-        desc.Format = DXGI_FORMAT_UNKNOWN;
-        desc.ViewDimension = D3D12_SRV_DIMENSION_BUFFER;
-        desc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-        desc.Buffer.NumElements = cellCount;
-        desc.Buffer.StructureByteStride = sizeof(UINT);
-        g_Engine->Device()->CreateShaderResourceView(m_gpuGridCount.Get(), &desc, m_gpuGridCountSRV->HandleCPU);
-    }
-    if (!m_gpuGridCountSRV)
-    {
-        printf("FluidSystem 10a : グリッドカウントSRVの登録に失敗しました\n");
-        m_gpuAvailable = false;
-        return;
-    }
-
-    if (!m_gpuGridCountUAV)
-    {
-        m_gpuGridCountUAV = g_Engine->CbvSrvUavHeap()->RegisterBufferUAV(m_gpuGridCount.Get(), cellCount, sizeof(UINT));
-    }
-    else
-    {
-        D3D12_UNORDERED_ACCESS_VIEW_DESC desc{};
-        desc.Format = DXGI_FORMAT_UNKNOWN;
-        desc.ViewDimension = D3D12_UAV_DIMENSION_BUFFER;
-        desc.Buffer.NumElements = cellCount;
-        desc.Buffer.StructureByteStride = sizeof(UINT);
-        g_Engine->Device()->CreateUnorderedAccessView(m_gpuGridCount.Get(), nullptr, &desc, m_gpuGridCountUAV->HandleCPU);
-    }
-    if (!m_gpuGridCountUAV)
-    {
-        printf("FluidSystem 10 : グリッドカウントUAVの登録に失敗しました\n");
-        m_gpuAvailable = false;
-        return;
-    }
-
-    auto tableDesc = CD3DX12_RESOURCE_DESC::Buffer(sizeof(UINT) * cellCount * kMaxParticlesPerCell, D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
-    HRESULT hrTable = device->CreateCommittedResource(&defaultHeap, D3D12_HEAP_FLAG_NONE, &tableDesc, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, nullptr,
-        IID_PPV_ARGS(m_gpuGridTable.ReleaseAndGetAddressOf()));
-    if (FAILED(hrTable))
-    {
-        printf("FluidSystem 11 : グリッドテーブル生成に失敗しました\n");
-        m_gpuAvailable = false;
-        return;
-    }
-    if (!m_gpuGridTableSRV)
-    {
-        m_gpuGridTableSRV = g_Engine->CbvSrvUavHeap()->RegisterBuffer(m_gpuGridTable.Get(), cellCount * kMaxParticlesPerCell, sizeof(UINT));
-    }
-    else
-    {
-        D3D12_SHADER_RESOURCE_VIEW_DESC desc{};
-        desc.Format = DXGI_FORMAT_UNKNOWN;
-        desc.ViewDimension = D3D12_SRV_DIMENSION_BUFFER;
-        desc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-        desc.Buffer.NumElements = cellCount * kMaxParticlesPerCell;
-        desc.Buffer.StructureByteStride = sizeof(UINT);
-        g_Engine->Device()->CreateShaderResourceView(m_gpuGridTable.Get(), &desc, m_gpuGridTableSRV->HandleCPU);
-    }
-    if (!m_gpuGridTableSRV)
-    {
-        printf("FluidSystem 11a : グリッドテーブルSRVの登録に失敗しました\n");
-        m_gpuAvailable = false;
-        return;
-    }
-
-    if (!m_gpuGridTableUAV)
-    {
-        m_gpuGridTableUAV = g_Engine->CbvSrvUavHeap()->RegisterBufferUAV(m_gpuGridTable.Get(), cellCount * kMaxParticlesPerCell, sizeof(UINT));
-    }
-    else
-    {
-        D3D12_UNORDERED_ACCESS_VIEW_DESC desc{};
-        desc.Format = DXGI_FORMAT_UNKNOWN;
-        desc.ViewDimension = D3D12_UAV_DIMENSION_BUFFER;
-        desc.Buffer.NumElements = cellCount * kMaxParticlesPerCell;
-        desc.Buffer.StructureByteStride = sizeof(UINT);
-        g_Engine->Device()->CreateUnorderedAccessView(m_gpuGridTable.Get(), nullptr, &desc, m_gpuGridTableUAV->HandleCPU);
-    }
-    if (!m_gpuGridTableUAV)
-    {
-        printf("FluidSystem 12 : グリッドテーブルUAVの登録に失敗しました\n");
-        m_gpuAvailable = false;
-        return;
-    }
-
-    // アップロード・リードバック
-    auto uploadHeap = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
-    auto uploadDesc = CD3DX12_RESOURCE_DESC::Buffer(particleBufferSize);
-    HRESULT hrUpload = device->CreateCommittedResource(&uploadHeap, D3D12_HEAP_FLAG_NONE, &uploadDesc, D3D12_RESOURCE_STATE_GENERIC_READ, nullptr,
-        IID_PPV_ARGS(m_gpuUpload.ReleaseAndGetAddressOf()));
-    if (FAILED(hrUpload))
-    {
-        printf("FluidSystem 13 : GPUアップロードバッファ生成に失敗しました\n");
-        m_gpuAvailable = false;
-        return;
-    }
-
-    auto readbackHeap = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_READBACK);
-    auto readbackDesc = CD3DX12_RESOURCE_DESC::Buffer(particleBufferSize);
-    HRESULT hrReadback = device->CreateCommittedResource(&readbackHeap, D3D12_HEAP_FLAG_NONE, &readbackDesc, D3D12_RESOURCE_STATE_COPY_DEST, nullptr,
-        IID_PPV_ARGS(m_gpuReadback.ReleaseAndGetAddressOf()));
-    if (FAILED(hrReadback))
-    {
-        printf("FluidSystem 14 : GPUリードバックバッファ生成に失敗しました\n");
-        m_gpuAvailable = false;
-        return;
-    }
-
-    // コンピュート用のルートシグネチャとPSOを構築する。
-    // それぞれのリソース種別に応じてテーブル／ルートディスクリプタを定義し、
-    // RootSignature の不整合による CreateComputePipelineState 失敗を避けるため、
-    // RegisterSpace や DescriptorRangeFlag を明示しておく。
-    CD3DX12_DESCRIPTOR_RANGE1 srvRange;
-    srvRange.Init(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
-
-    CD3DX12_DESCRIPTOR_RANGE1 uavRanges[4];
-    uavRanges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_UAV, 1, 0, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
-    uavRanges[1].Init(D3D12_DESCRIPTOR_RANGE_TYPE_UAV, 1, 1, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
-    uavRanges[2].Init(D3D12_DESCRIPTOR_RANGE_TYPE_UAV, 1, 2, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
-    uavRanges[3].Init(D3D12_DESCRIPTOR_RANGE_TYPE_UAV, 1, 3, 0, D3D12_DESCRIPTOR_RANGE_FLAG_DATA_STATIC);
-
-    CD3DX12_ROOT_PARAMETER1 params[7] = {};
-    params[0].InitAsConstantBufferView(0, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_STATIC);
-    params[1].InitAsConstantBufferView(1, 0, D3D12_ROOT_DESCRIPTOR_FLAG_DATA_STATIC);
-    params[2].InitAsDescriptorTable(1, &srvRange);
-    params[3].InitAsDescriptorTable(1, &uavRanges[0]);
-    params[4].InitAsDescriptorTable(1, &uavRanges[1]);
-    params[5].InitAsDescriptorTable(1, &uavRanges[2]);
-    params[6].InitAsDescriptorTable(1, &uavRanges[3]);
-
-    CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC rootDesc;
-    rootDesc.Init_1_1(_countof(params), params, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_NONE);
-
-    ComPtr<ID3DBlob> serialized;
-    ComPtr<ID3DBlob> errors;
-    HRESULT hrSerialize = D3D12SerializeVersionedRootSignature(&rootDesc, serialized.GetAddressOf(), errors.GetAddressOf());
-    if (FAILED(hrSerialize))
-    {
-        if (errors)
-        {
-            printf("Compute root signature error: %s\n", static_cast<const char*>(errors->GetBufferPointer()));
-        }
-        return;
-    }
-    HRESULT hrRoot = device->CreateRootSignature(0, serialized->GetBufferPointer(), serialized->GetBufferSize(), IID_PPV_ARGS(m_computeRootSignature.ReleaseAndGetAddressOf()));
-    if (FAILED(hrRoot))
-    {
-        printf("FluidSystem 15 : コンピュート用ルートシグネチャ生成に失敗しました\n");
-        m_gpuAvailable = false;
-        return;
-    }
-
-    m_clearGridPipeline = std::make_unique<ComputePipelineState>();
-    m_clearGridPipeline->SetDevice(device);
-    m_clearGridPipeline->SetRootSignature(m_computeRootSignature.Get());
-    m_clearGridPipeline->SetCS(L"ClearGridCS.cso");
-    if (!m_clearGridPipeline->Create())
-    {
-        m_clearGridPipeline.reset();
-        m_buildGridPipeline.reset();
-        m_particlePipeline.reset();
-        m_gpuAvailable = false;
-        return;
-    }
-
-    m_buildGridPipeline = std::make_unique<ComputePipelineState>();
-    m_buildGridPipeline->SetDevice(device);
-    m_buildGridPipeline->SetRootSignature(m_computeRootSignature.Get());
-    m_buildGridPipeline->SetCS(L"BuildGridCS.cso");
-    if (!m_buildGridPipeline->Create())
-    {
-        m_buildGridPipeline.reset();
-        m_particlePipeline.reset();
-        m_clearGridPipeline.reset();
-        m_gpuAvailable = false;
-        return;
-    }
-
-    m_particlePipeline = std::make_unique<ComputePipelineState>();
-    m_particlePipeline->SetDevice(device);
-    m_particlePipeline->SetRootSignature(m_computeRootSignature.Get());
-    m_particlePipeline->SetCS(L"ParticleCS.cso");
-    if (!m_particlePipeline->Create())
-    {
-        m_particlePipeline.reset();
-        m_buildGridPipeline.reset();
-        m_clearGridPipeline.reset();
-        m_gpuAvailable = false;
-        return;
-    }
-
-    // コンピュート用のコマンドアロケーター／リスト／フェンスを準備
-    if (!m_computeAllocator)
-    {
-        HRESULT hrAlloc = device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_COMPUTE, IID_PPV_ARGS(m_computeAllocator.ReleaseAndGetAddressOf()));
-        if (FAILED(hrAlloc))
-        {
-            printf("FluidSystem 16 : コンピュート用アロケーター生成に失敗しました\n");
-            m_gpuAvailable = false;
-            return;
-        }
-    }
-
-    if (!m_computeCommandList)
-    {
-        HRESULT hrList = device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_COMPUTE, m_computeAllocator.Get(), nullptr, IID_PPV_ARGS(m_computeCommandList.ReleaseAndGetAddressOf()));
-        if (FAILED(hrList))
-        {
-            printf("FluidSystem 17 : コンピュート用コマンドリスト生成に失敗しました\n");
-            m_gpuAvailable = false;
-            return;
-        }
-        // 生成直後は開いているので一度閉じておく
-        m_computeCommandList->Close();
-    }
-
-    if (!m_computeFence)
-    {
-        HRESULT hrFence = device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(m_computeFence.ReleaseAndGetAddressOf()));
-        if (FAILED(hrFence))
-        {
-            printf("FluidSystem 18 : コンピュート用フェンス生成に失敗しました\n");
-            m_gpuAvailable = false;
-            return;
-        }
-        m_computeFenceValue = 0;
-        m_lastSubmittedComputeFence = 0;
-    }
-
-    if (!m_computeFenceEvent)
-    {
-        m_computeFenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-        if (!m_computeFenceEvent)
-        {
-            printf("FluidSystem 19 : フェンスイベント生成に失敗しました\n");
-            m_gpuAvailable = false;
-            return;
-        }
-    }
-
-    m_gpuReadIndex = 0;
-    m_pendingReadback = false;
-    m_gpuDirty = true;
-
-    // 必須リソースが揃ったか最終チェックし、足りない場合はGPUモードを無効化する
-    m_gpuAvailable = HasValidGPUResources();
-    if (!m_gpuAvailable)
-    {
-        printf("FluidSystem ERROR: GPUリソースの作成が不完全なためGPUシミュレーションを無効化しました\n");
-        m_useGPU = false;
-    }
-}
-
-// FluidSystem.cpp: BeginComputeCommandList
-ID3D12GraphicsCommandList* FluidSystem::BeginComputeCommandList()
-{
-    if (!m_computeAllocator || !m_computeCommandList || !m_computeFence || !m_computeFenceEvent)
-    {
-        return nullptr;
-    }
-
-    // 直前に発行したコンピュートコマンドの実行が終わるまで待機する
-    if (m_computeFence->GetCompletedValue() < m_lastSubmittedComputeFence)
-    {
-        // GPUが完了したときにイベントが発火するように設定し、待機する
-        HRESULT hr = m_computeFence->SetEventOnCompletion(m_lastSubmittedComputeFence, m_computeFenceEvent);
-        if (FAILED(hr))
-        {
-            printf("FluidSystem ERROR: Failed to set event on completion. Disabling GPU simulation.\n");
-            m_gpuAvailable = false;
-            return nullptr;
-        }
-        WaitForSingleObject(m_computeFenceEvent, INFINITE);
-    }
-
-    // GPUの処理が完了したので、アロケーターとコマンドリストを安全にリセットできる
-    HRESULT hrAlloc = m_computeAllocator->Reset();
-    if (FAILED(hrAlloc))
-    {
-        // HRESULT をログに出力して詳細な原因を追跡しやすくする
-        printf("FluidSystem 20 : Compute allocator reset failed (HRESULT: 0x%08X).\n", hrAlloc);
-        if (hrAlloc == DXGI_ERROR_DEVICE_REMOVED)
-        {
-            HRESULT reason = m_device->GetDeviceRemovedReason();
-            printf("    Reason: Device Removed (0x%08X)\n", reason);
-        }
-        // 回復不能なエラーとみなし、GPUシミュレーションを無効化してCPUにフォールバックさせる
-        printf("    Disabling GPU simulation due to an unrecoverable error.\n");
-        m_gpuAvailable = false;
-        return nullptr;
-    }
-
-    HRESULT hrCmd = m_computeCommandList->Reset(m_computeAllocator.Get(), nullptr);
-    if (FAILED(hrCmd))
-    {
-        // HRESULT をログに出力
-        printf("FluidSystem 21 : Compute Commandlist Reset failed (HRESULT: 0x%08X).\n", hrCmd);
-        if (hrCmd == DXGI_ERROR_DEVICE_REMOVED)
-        {
-            HRESULT reason = m_device->GetDeviceRemovedReason();
-            printf("    Reason: Device Removed (0x%08X)\n", reason);
-        }
-        // こちらも同様に、エラー発生時はGPUシミュレーションを無効化
-        printf("    Disabling GPU simulation due to an unrecoverable error.\n");
-        m_gpuAvailable = false;
-        return nullptr;
-    }
-
-    return m_computeCommandList.Get();
-}
-
-// FluidSystem.cpp: SubmitComputeCommandList (修正後)
-void FluidSystem::SubmitComputeCommandList()
-{
-    if (!m_computeCommandList)
-    {
-        return;
-    }
-
-    HRESULT hrClose = m_computeCommandList->Close();
-    if (FAILED(hrClose))
-    {
-        printf("FluidSystem 22 : compute command list close failed\n");
-        m_gpuAvailable = false;
-        m_useGPU = false;
-        return;
-    }
-
-    ID3D12CommandList* lists[] = { m_computeCommandList.Get() };
-    ID3D12CommandQueue* queue = g_Engine->ComputeCommandQueue();
-    if (!queue)
-    {
-        // コンピュートキューが無ければ描画キューで代用
-        queue = g_Engine->CommandQueue();
-    }
-
-    if (!queue)
-    {
-        return;
-    }
-
-    queue->ExecuteCommandLists(1, lists);
-
-    if (m_computeFence)
-    {
-        // 待つべき目標値を先に更新する
-        m_computeFenceValue++;
-        m_lastSubmittedComputeFence = m_computeFenceValue;
-
-        if (FAILED(queue->Signal(m_computeFence.Get(), m_lastSubmittedComputeFence)))
-        {
-            // Signalの失敗は致命的なので、GPUシミュレーションを無効にする
-            printf("FluidSystem ERROR: Failed to signal the compute fence. Disabling GPU simulation.\n");
-            m_gpuAvailable = false;
-            return; // これ以上続行しない
-        }
-
-        // グラフィックスキューはコンピュート結果を待ってから描画を継続
-        if (ID3D12CommandQueue* graphicsQueue = g_Engine->CommandQueue())
-        {
-            if (graphicsQueue != queue)
+            for (UINT x = 0; x < perRow && index < particleCount; ++x)
             {
-                graphicsQueue->Wait(m_computeFence.Get(), m_lastSubmittedComputeFence);
+                float px = std::min(startX + x * spacing, maxX);
+                float py = std::min(startY + y * spacing, maxY);
+                float pz = std::min(startZ + z * spacing, maxZ);
+
+                px += jitter(rng);
+                py += jitter(rng);
+                pz += jitter(rng);
+
+                Particle particle{};
+                particle.position = XMFLOAT3(px, py, pz);
+                particle.velocity = XMFLOAT3(0.0f, 0.0f, 0.0f);
+                m_particles[index] = particle;
+
+                m_renderVertices[index].position = particle.position;
+                ++index;
             }
         }
     }
 }
 
-bool FluidSystem::HasValidGPUResources() const
+void FluidSystem::Update(float deltaTime)
 {
-    // ディスクリプタハンドルが有効かを確認するラムダ
-    auto isValidHandle = [](const DescriptorHandle* handle)
-    {
-        return handle && handle->HandleCPU.ptr != 0 && handle->HandleGPU.ptr != 0;
-    };
+    const float dt = std::clamp(deltaTime, 0.0f, 0.033f); // 極端なデルタタイムを抑制
+    const float gravityStep = kGravity * dt;
+    const float dragFactor = std::clamp(1.0f - m_drag * dt, 0.0f, 1.0f);
 
-    if (!m_gpuMetaBuffer || !isValidHandle(m_gpuMetaSRV) || !isValidHandle(m_gpuMetaUAV))
+    for (auto& particle : m_particles)
     {
-        return false;
+        particle.velocity.y += gravityStep;
+        particle.velocity.x *= dragFactor;
+        particle.velocity.y *= dragFactor;
+        particle.velocity.z *= dragFactor;
+
+        particle.position.x += particle.velocity.x * dt;
+        particle.position.y += particle.velocity.y * dt;
+        particle.position.z += particle.velocity.z * dt;
+
+        ResolveCollisions(particle);
     }
 
-    for (const auto& buffer : m_gpuParticleBuffers)
+    UpdateVertexBuffer();
+}
+
+void FluidSystem::ResolveCollisions(Particle& particle) const
+{
+    const float minX = m_bounds.min.x + m_particleRadius + kWallThickness;
+    const float maxX = m_bounds.max.x - m_particleRadius - kWallThickness;
+    const float minY = m_bounds.min.y + m_particleRadius + kWallThickness;
+    const float maxY = m_bounds.max.y - m_particleRadius - kWallThickness;
+    const float minZ = m_bounds.min.z + m_particleRadius + kWallThickness;
+    const float maxZ = m_bounds.max.z - m_particleRadius - kWallThickness;
+
+    if (particle.position.x < minX)
     {
-        if (!buffer.resource || !isValidHandle(buffer.srv) || !isValidHandle(buffer.uav))
+        particle.position.x = minX;
+        if (particle.velocity.x < 0.0f)
         {
-            return false;
+            particle.velocity.x *= -m_restitution;
+        }
+    }
+    else if (particle.position.x > maxX)
+    {
+        particle.position.x = maxX;
+        if (particle.velocity.x > 0.0f)
+        {
+            particle.velocity.x *= -m_restitution;
         }
     }
 
-    if (!m_gpuGridCount || !isValidHandle(m_gpuGridCountSRV) || !isValidHandle(m_gpuGridCountUAV))
+    if (particle.position.y < minY)
     {
-        return false;
+        particle.position.y = minY;
+        if (particle.velocity.y < 0.0f)
+        {
+            particle.velocity.y *= -m_restitution;
+        }
+    }
+    else if (particle.position.y > maxY)
+    {
+        particle.position.y = maxY;
+        if (particle.velocity.y > 0.0f)
+        {
+            particle.velocity.y *= -m_restitution;
+        }
     }
 
-    if (!m_gpuGridTable || !isValidHandle(m_gpuGridTableSRV) || !isValidHandle(m_gpuGridTableUAV))
+    if (particle.position.z < minZ)
     {
-        return false;
+        particle.position.z = minZ;
+        if (particle.velocity.z < 0.0f)
+        {
+            particle.velocity.z *= -m_restitution;
+        }
     }
-
-    if (!m_gpuUpload || !m_gpuReadback)
+    else if (particle.position.z > maxZ)
     {
-        return false;
+        particle.position.z = maxZ;
+        if (particle.velocity.z > 0.0f)
+        {
+            particle.velocity.z *= -m_restitution;
+        }
     }
-
-    if (!m_buildGridPipeline || !m_particlePipeline || !m_clearGridPipeline || !m_computeRootSignature)
-    {
-        return false;
-    }
-
-    return true;
 }
 
-void FluidSystem::UpdateGridSettings()
+void FluidSystem::UpdateVertexBuffer()
 {
-    float cellSize = std::max(0.02f, m_material.smoothingRadius);
-    m_spatialGrid.SetCellSize(cellSize);
+    for (size_t i = 0; i < m_particles.size(); ++i)
+    {
+        m_renderVertices[i].position = m_particles[i].position;
+    }
 
-    float width = m_boundsMax.x - m_boundsMin.x;
-    float height = m_boundsMax.y - m_boundsMin.y;
-    float depth = m_boundsMax.z - m_boundsMin.z;
+    if (!m_vertexBuffer)
+    {
+        return;
+    }
 
-    m_gridDim.x = std::max<UINT>(1u, static_cast<UINT>(std::ceil(width / cellSize)));
-    m_gridDim.y = std::max<UINT>(1u, static_cast<UINT>(std::ceil(height / cellSize)));
-    m_gridDim.z = std::max<UINT>(1u, static_cast<UINT>(std::ceil(depth / cellSize)));
+    void* mapped = nullptr;
+    auto resource = m_vertexBuffer->GetResource();
+    if (resource && SUCCEEDED(resource->Map(0, nullptr, &mapped)))
+    {
+        memcpy(mapped, m_renderVertices.data(), sizeof(ParticleVertex) * m_renderVertices.size());
+        resource->Unmap(0, nullptr);
+    }
+}
+
+void FluidSystem::Draw(ID3D12GraphicsCommandList* cmd, const Camera& camera)
+{
+    if (!cmd || !m_vertexBuffer || !m_pipelineState || !m_rootSignature)
+    {
+        return;
+    }
+
+    UINT frameIndex = g_Engine->CurrentBackBufferIndex();
+    auto& cb = m_constantBuffers[frameIndex];
+    if (!cb)
+    {
+        return;
+    }
+
+    FluidConstant* constant = cb->GetPtr<FluidConstant>();
+    constant->World = m_world;
+    constant->View = camera.GetViewMatrix();
+    constant->Proj = camera.GetProjMatrix();
+
+    cmd->SetGraphicsRootSignature(m_rootSignature->Get());
+    cmd->SetPipelineState(m_pipelineState->Get());
+    cmd->SetGraphicsRootConstantBufferView(0, cb->GetAddress());
+
+    auto vbView = m_vertexBuffer->View();
+    cmd->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_POINTLIST);
+    cmd->IASetVertexBuffers(0, 1, &vbView);
+    cmd->DrawInstanced(static_cast<UINT>(m_particles.size()), 1, 0, 0);
+}
+
+void FluidSystem::SetBounds(const Bounds& bounds)
+{
+    m_bounds = bounds;
+    for (auto& particle : m_particles)
+    {
+        ResolveCollisions(particle);
+    }
+    UpdateVertexBuffer();
+}
+
+void FluidSystem::MoveBounds(const XMFLOAT3& delta)
+{
+    m_bounds.min.x += delta.x;
+    m_bounds.min.y += delta.y;
+    m_bounds.min.z += delta.z;
+    m_bounds.max.x += delta.x;
+    m_bounds.max.y += delta.y;
+    m_bounds.max.z += delta.z;
+
+    for (auto& particle : m_particles)
+    {
+        particle.position.x += delta.x;
+        particle.position.y += delta.y;
+        particle.position.z += delta.z;
+    }
+    UpdateVertexBuffer();
 }

--- a/DirectX12/FluidSystem.h
+++ b/DirectX12/FluidSystem.h
@@ -1,332 +1,66 @@
 #pragma once
-#include "ComPtr.h"
 #include "ConstantBuffer.h"
-#include "DescriptorHeap.h"
+#include "Engine.h"
+#include "PipelineState.h"
+#include "RootSignature.h"
 #include "SharedStruct.h"
-#include "SpatialGrid.h"
-#include "ComputePipelineState.h"
-#include "Texture2D.h"
-#include <d3d12.h>
-#include <wrl.h>
+#include "VertexBuffer.h"
 #include <DirectXMath.h>
 #include <array>
 #include <memory>
 #include <vector>
-#include <Windows.h>
 
-// ================================
-//  流体マテリアルの設定パラメータ
-// ================================
-struct FluidMaterial
-{
-    float restDensity = 1000.0f;      // 静止密度
-    float particleMass = 1.0f;        // 粒子質量
-    float smoothingRadius = 0.12f;    // カーネル半径
-    float viscosity = 0.02f;          // 粘性係数
-    float stiffness = 200.0f;         // 圧力係数（GPU用）
-    float renderRadius = 0.10f;       // メタボール描画半径
-    float lambdaEpsilon = 100.0f;     // PBF安定化係数
-    float xsphC = 0.05f;              // XSPH粘性（CPU）
-    int   solverIterations = 1;       // PBF反復回数（安定動作用に軽量化）
-};
+class Camera;
 
-// プリセットマテリアル
-enum class FluidMaterialPreset
-{
-    Water,
-    Magma,
-};
-
-// シミュレーションモード
-enum class FluidSimulationMode
-{
-    CPU,
-    GPU,
-};
-
-// CPU シミュレーション用の粒子情報
-struct FluidParticle
-{
-    DirectX::XMFLOAT3 position;   // 現在位置
-    DirectX::XMFLOAT3 velocity;   // 速度
-    DirectX::XMFLOAT3 predicted;  // 予測位置
-    float lambda = 0.0f;          // PBFラグランジュ乗数
-    float density = 0.0f;         // 計算密度
-    UINT  collisionMask = 0;      // 衝突が発生した境界を保持するビットマスク
-};
-
-// 流体が境界へ衝突した際に通知するイベント
-struct FluidCollisionEvent
-{
-    DirectX::XMFLOAT3 position;   // 衝突位置
-    DirectX::XMFLOAT3 normal;     // 衝突面の法線
-    float               strength; // 衝突の強さ（速度から算出）
-};
-
+// 流体システム。粒子の管理と壁との当たり判定、描画を担当する。
 class FluidSystem
 {
 public:
+    struct Bounds
+    {
+        DirectX::XMFLOAT3 min; // AABB最小点
+        DirectX::XMFLOAT3 max; // AABB最大点
+    };
+
     FluidSystem();
-    ~FluidSystem();
+    ~FluidSystem() = default;
 
-    void Init(ID3D12Device* device, DXGI_FORMAT rtvFormat, UINT maxParticles, UINT threadGroupCount);
+    bool Init(ID3D12Device* device, const Bounds& initialBounds, UINT particleCount);
+    void Update(float deltaTime);
+    void Draw(ID3D12GraphicsCommandList* cmd, const Camera& camera);
 
-    void UseGPU(bool enable);
-    FluidSimulationMode Mode() const;
-
-    void SetMaterialPreset(FluidMaterialPreset preset);
-    void SetMaterial(const FluidMaterial& material);
-    void SetSimulationBounds(const DirectX::XMFLOAT3& minBound, const DirectX::XMFLOAT3& maxBound);
-    const FluidMaterial& Material() const { return m_material; }
-
-    void SpawnParticlesSphere(const DirectX::XMFLOAT3& center, float radius, UINT count);
-    void RemoveParticlesSphere(const DirectX::XMFLOAT3& center, float radius);
-
-    void QueueGather(const DirectX::XMFLOAT3& target, float radius, float strength);
-    void QueueSplash(const DirectX::XMFLOAT3& position, float radius, float impulse);
-    void QueueDirectionalImpulse(const DirectX::XMFLOAT3& center, float radius, const DirectX::XMFLOAT3& direction, float strength);
-    void ClearDynamicOperations();
-
-    bool Raycast(const DirectX::XMFLOAT3& origin, const DirectX::XMFLOAT3& direction, float maxDistance, float radius, DirectX::XMFLOAT3& hitPosition) const;
-    void PopCollisionEvents(std::vector<FluidCollisionEvent>& outEvents);
-
-    void Simulate(ID3D12GraphicsCommandList* cmd, float dt);
-    void Render(ID3D12GraphicsCommandList* cmd,
-        const DirectX::XMFLOAT4X4& view,
-        const DirectX::XMFLOAT4X4& proj,
-        const DirectX::XMFLOAT4X4& viewProj,
-        const DirectX::XMFLOAT3& camPos,
-        float isoLevel);
-
-    void Composite(ID3D12GraphicsCommandList* cmd,
-        ID3D12Resource* sceneColor,
-        ID3D12Resource* sceneDepth,
-        D3D12_CPU_DESCRIPTOR_HANDLE sceneRTV);
-
-    // 水面のカラーや泡の強さを外部から調整できるようにする
-    void SetWaterAppearance(const DirectX::XMFLOAT3& shallowColor,
-        const DirectX::XMFLOAT3& deepColor,
-        float absorption,
-        float foamThreshold,
-        float foamStrength,
-        float reflectionStrength,
-        float specularPower);
-
-    void StartDrag(int, int, class Camera*) {}
-    void Drag(int, int, class Camera*) {}
-    void EndDrag() {}
+    void SetBounds(const Bounds& bounds);
+    void MoveBounds(const DirectX::XMFLOAT3& delta);
+    const Bounds& GetBounds() const { return m_bounds; }
 
 private:
-    struct SSFRCameraConstants
+    struct Particle
     {
-        DirectX::XMFLOAT4X4 View;        // ビュー行列（転置済み）
-        DirectX::XMFLOAT4X4 Proj;        // 射影行列（転置済み）
-        DirectX::XMFLOAT4X4 ViewProj;    // ビュー射影行列（転置済み）
-        DirectX::XMFLOAT2   ScreenSize;  // 画面解像度
-        DirectX::XMFLOAT2   InvScreen;   // 逆解像度
-        float               NearZ;       // ニア平面
-        float               FarZ;        // ファー平面
-        DirectX::XMFLOAT3   IorF0;       // フレネル用F0
-        float               Absorption;  // Beer-Lambert係数
+        DirectX::XMFLOAT3 position; // 現在位置
+        DirectX::XMFLOAT3 velocity; // 速度ベクトル
     };
 
-    struct SSFRBlurParams
+    struct FluidConstant
     {
-        float Sigma;  // 空間ガウス係数
-        float DepthK; // 深度差係数
-        float NormalK;// 法線差係数
-        float Padding;// 16byte揃え
+        DirectX::XMMATRIX World; // ワールド行列
+        DirectX::XMMATRIX View;  // ビュー行列
+        DirectX::XMMATRIX Proj;  // プロジェクション行列
     };
 
-    struct GPUParams
-    {
-        float restDensity;
-        float particleMass;
-        float viscosity;
-        float stiffness;
-        float radius;
-        float timeStep;
-        UINT  particleCount;
-        UINT  pad0;
-        DirectX::XMFLOAT3 gridMin;
-        float pad1;
-        DirectX::XMUINT3  gridDim;
-        UINT  pad2;
-    };
+    void InitializeParticles(UINT particleCount);
+    void ResolveCollisions(Particle& particle) const;
+    void UpdateVertexBuffer();
 
-    struct GatherOperation
-    {
-        DirectX::XMFLOAT3 target;
-        float radius;
-        float strength;
-    };
+    std::vector<Particle> m_particles;               // 流体粒子
+    std::vector<ParticleVertex> m_renderVertices;    // 描画用頂点
+    std::unique_ptr<VertexBuffer> m_vertexBuffer;    // 粒子描画用VB
+    std::unique_ptr<RootSignature> m_rootSignature;  // 粒子描画用ルートシグネチャ
+    std::unique_ptr<PipelineState> m_pipelineState;  // 粒子描画用PSO
+    std::array<std::unique_ptr<ConstantBuffer>, Engine::FRAME_BUFFER_COUNT> m_constantBuffers; // 定数バッファ
 
-    struct SplashOperation
-    {
-        DirectX::XMFLOAT3 origin;
-        float radius;
-        float impulse;
-    };
-
-    struct DirectionalImpulseOperation
-    {
-        DirectX::XMFLOAT3 center;
-        float radius;
-        DirectX::XMFLOAT3 direction;
-        float strength;
-    };
-
-    struct GPUBufferHandle
-    {
-        Microsoft::WRL::ComPtr<ID3D12Resource> resource;
-        DescriptorHandle* srv = nullptr;
-        DescriptorHandle* uav = nullptr;
-        D3D12_RESOURCE_STATES state = D3D12_RESOURCE_STATE_COMMON;
-    };
-
-    static constexpr UINT kMaxParticlesPerCell = 64; // グリッド1セルが保持できる粒子数の上限
-    static constexpr UINT kCollisionMinX = 1u << 0;
-    static constexpr UINT kCollisionMaxX = 1u << 1;
-    static constexpr UINT kCollisionMinY = 1u << 2;
-    static constexpr UINT kCollisionMaxY = 1u << 3;
-    static constexpr UINT kCollisionMinZ = 1u << 4;
-    static constexpr UINT kCollisionMaxZ = 1u << 5;
-
-    void UpdateGridSettings();
-    void ApplyExternalOperationsCPU(float dt);
-    void StepCPU(float dt);
-    void StepGPU(ID3D12GraphicsCommandList* cmd, float dt);
-    void UploadCPUToGPU(ID3D12GraphicsCommandList* cmd);
-    void ReadbackGPUToCPU();
-    void UpdateParticleBuffer();
-    bool CreateSSFRResources(ID3D12Device* device, DXGI_FORMAT rtvFormat);
-    void DestroySSFRResources();
-    void CreateGPUResources(ID3D12Device* device);
-    void UpdateComputeParams(float dt);
-    UINT ResolveBounds(FluidParticle& p) const;
-    ID3D12GraphicsCommandList* BeginComputeCommandList();
-    void SubmitComputeCommandList();
-    bool HasValidGPUResources() const;
-
-    float EffectiveTimeStep(float dt) const;
-
-    // CPU管理
-    std::vector<FluidParticle> m_cpuParticles;
-    SpatialGrid                m_spatialGrid;
-
-    // 描画関連
-    static constexpr UINT kFrameCount = 2;
-    std::array<std::unique_ptr<ConstantBuffer>, kFrameCount> m_cameraCB{}; // カメラ定数バッファ
-    std::unique_ptr<ConstantBuffer> m_blurParamsCB;                        // ブラー用定数
-    Microsoft::WRL::ComPtr<ID3D12Resource> m_cpuMetaBuffer;                // 粒子インスタンスデータ（CPU側）
-    Microsoft::WRL::ComPtr<ID3D12Resource> m_gpuMetaBuffer;                // 粒子インスタンスデータ（GPU側）
-    DescriptorHandle* m_cpuMetaSRV = nullptr;                              // CPU粒子のSRV
-    DescriptorHandle* m_gpuMetaSRV = nullptr;                              // GPU粒子のSRV
-    DescriptorHandle* m_gpuMetaUAV = nullptr;                              // GPU粒子のUAV
-    DescriptorHandle* m_activeMetaSRV = nullptr;                           // 現在描画に利用する粒子SRV
-
-    // SSFR用テクスチャ
-    std::unique_ptr<Texture2D> m_particleDepthTexture;                     // 粒子の深度
-    std::unique_ptr<Texture2D> m_smoothedDepthTexture;                     // 平滑化後の深度
-    std::unique_ptr<Texture2D> m_normalTexture;                            // 法線
-    std::unique_ptr<Texture2D> m_thicknessTexture;                         // 厚み
-
-    DescriptorHandle* m_particleDepthSRV = nullptr;
-    DescriptorHandle* m_particleDepthUAV = nullptr;
-    DescriptorHandle* m_smoothedDepthSRV = nullptr;
-    DescriptorHandle* m_smoothedDepthUAV = nullptr;
-    DescriptorHandle* m_normalSRV = nullptr;
-    DescriptorHandle* m_normalUAV = nullptr;
-    DescriptorHandle* m_thicknessSRV = nullptr;
-    DescriptorHandle* m_thicknessUAV = nullptr;
-
-    DescriptorHandle* m_sceneColorSRV = nullptr;
-    DescriptorHandle* m_sceneDepthSRV = nullptr;
-    Microsoft::WRL::ComPtr<ID3D12Resource> m_sceneColorCopy;
-    D3D12_RESOURCE_STATES m_sceneColorCopyState = D3D12_RESOURCE_STATE_COMMON;
-    D3D12_RESOURCE_STATES m_sceneDepthState = D3D12_RESOURCE_STATE_DEPTH_WRITE;
-
-    Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> m_ssfrRtvHeap;            // RTV専用ヒープ
-    UINT m_ssfrRtvDescriptorSize = 0;
-    D3D12_CPU_DESCRIPTOR_HANDLE m_particleDepthRTV = {};
-    D3D12_CPU_DESCRIPTOR_HANDLE m_smoothedDepthRTV = {};
-    D3D12_CPU_DESCRIPTOR_HANDLE m_thicknessRTV = {};
-
-    Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> m_ssfrCpuUavHeap;         // UAVクリア用CPUヒープ
-    UINT m_ssfrCpuUavDescriptorSize = 0;
-    D3D12_CPU_DESCRIPTOR_HANDLE m_particleDepthUavCpuHandle = {};
-    D3D12_CPU_DESCRIPTOR_HANDLE m_smoothedDepthUavCpuHandle = {};
-
-    D3D12_RESOURCE_STATES m_particleDepthState = D3D12_RESOURCE_STATE_COMMON;
-    D3D12_RESOURCE_STATES m_smoothedDepthState = D3D12_RESOURCE_STATE_COMMON;
-    D3D12_RESOURCE_STATES m_normalState = D3D12_RESOURCE_STATE_COMMON;
-    D3D12_RESOURCE_STATES m_thicknessState = D3D12_RESOURCE_STATE_COMMON;
-
-    // SSFR用ルートシグネチャとPSO
-    Microsoft::WRL::ComPtr<ID3D12RootSignature> m_particleRootSignature;
-    Microsoft::WRL::ComPtr<ID3D12PipelineState> m_particlePipelineState;
-    Microsoft::WRL::ComPtr<ID3D12RootSignature> m_blurRootSignature;
-    Microsoft::WRL::ComPtr<ID3D12PipelineState> m_blurPipelineState;
-    Microsoft::WRL::ComPtr<ID3D12RootSignature> m_normalRootSignature;
-    Microsoft::WRL::ComPtr<ID3D12PipelineState> m_normalPipelineState;
-    Microsoft::WRL::ComPtr<ID3D12RootSignature> m_compositeRootSignature;
-    Microsoft::WRL::ComPtr<ID3D12PipelineState> m_compositePipelineState;
-
-    // GPUシミュレーション関連
-    bool m_useGPU = false;
-    bool m_gpuAvailable = false;
-    bool m_cpuDirty = true;
-    bool m_gpuDirty = true;
-    bool m_pendingReadback = false;
-    UINT m_gpuReadIndex = 0;
-    GPUBufferHandle m_gpuParticleBuffers[2];
-    Microsoft::WRL::ComPtr<ID3D12Resource> m_gpuGridCount;
-    Microsoft::WRL::ComPtr<ID3D12Resource> m_gpuGridTable;
-    DescriptorHandle* m_gpuGridCountSRV = nullptr;
-    DescriptorHandle* m_gpuGridTableSRV = nullptr;
-    DescriptorHandle* m_gpuGridCountUAV = nullptr;
-    DescriptorHandle* m_gpuGridTableUAV = nullptr;
-    Microsoft::WRL::ComPtr<ID3D12Resource> m_gpuUpload;
-    Microsoft::WRL::ComPtr<ID3D12Resource> m_gpuReadback;
-    std::unique_ptr<ConstantBuffer> m_computeParamsCB;
-    std::unique_ptr<ConstantBuffer> m_dummyViewCB;
-    Microsoft::WRL::ComPtr<ID3D12RootSignature> m_computeRootSignature;
-    std::unique_ptr<ComputePipelineState> m_buildGridPipeline;
-    std::unique_ptr<ComputePipelineState> m_particlePipeline;
-    std::unique_ptr<ComputePipelineState> m_clearGridPipeline;
-    Microsoft::WRL::ComPtr<ID3D12CommandAllocator> m_computeAllocator;
-    Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList> m_computeCommandList;
-    Microsoft::WRL::ComPtr<ID3D12Fence> m_computeFence;
-    HANDLE m_computeFenceEvent = nullptr;
-    UINT64 m_computeFenceValue = 0;
-    UINT64 m_lastSubmittedComputeFence = 0;
-
-    // 共通設定
-    FluidMaterial m_material;
-    DirectX::XMFLOAT3 m_boundsMin;
-    DirectX::XMFLOAT3 m_boundsMax;
-    DirectX::XMUINT3  m_gridDim;
-    UINT              m_particleCount = 0;
-    UINT              m_maxParticles = 0;
-    bool              m_initialized = false;
-
-    std::vector<GatherOperation> m_gatherOps;
-    std::vector<SplashOperation> m_splashOps;
-    std::vector<DirectionalImpulseOperation> m_directionalOps;
-    std::vector<FluidCollisionEvent> m_collisionEvents;
-
-    ID3D12Device* m_device = nullptr;
-    DXGI_FORMAT   m_rtvFormat = DXGI_FORMAT_R8G8B8A8_UNORM;
-
-    DirectX::XMFLOAT3 m_waterColorDeep;
-    DirectX::XMFLOAT3 m_waterColorShallow;
-    float m_waterAbsorption = 0.35f;
-    float m_foamCurvatureThreshold = 0.45f;
-    float m_foamStrength = 0.35f;
-    float m_reflectionStrength = 0.6f;
-    float m_specularPower = 64.0f;
-    float m_totalSimulatedTime = 0.0f;
+    Bounds m_bounds{};             // 現在の境界
+    DirectX::XMMATRIX m_world;     // 粒子全体のワールド行列
+    float m_particleRadius = 0.05f; // 粒子半径
+    float m_restitution = 0.4f;     // 壁衝突時の反発係数
+    float m_drag = 0.1f;            // 簡易減衰係数
 };
-
-// プリセットマテリアルの生成ヘルパー
-FluidMaterial CreateFluidMaterial(FluidMaterialPreset preset);

--- a/DirectX12/GameScene.cpp
+++ b/DirectX12/GameScene.cpp
@@ -1,206 +1,288 @@
 #include "GameScene.h"
-#include "Game.h"
+#include "DebugCube.h"
 #include "Engine.h"
-#include "App.h"
+#include "Camera.h"
 #include <algorithm>
-#include <random>
 #include <cstring>
-#include <cstddef>
+#include <vector>
 
 using namespace DirectX;
 
-namespace
+namespace GameSceneDetail
 {
-    constexpr DXGI_FORMAT kBackBufferFormat = DXGI_FORMAT_R8G8B8A8_UNORM;
-    constexpr float kMaxRayDistance = 20.0f; // レイ判定距離の上限
+    struct WallVertex
+    {
+        XMFLOAT3 position; // 頂点座標
+        XMFLOAT4 color;    // RGBA 色
+    };
+
+    struct WallConstant
+    {
+        XMFLOAT4X4 view; // ビュー行列（転置済み）
+        XMFLOAT4X4 proj; // プロジェクション行列（転置済み）
+    };
+
+    // 透明な壁の描画を担当する補助クラス
+    class TransparentWalls
+    {
+    public:
+        bool Init(const FluidSystem::Bounds& bounds)
+        {
+            m_cachedBounds = bounds;
+            BuildVertices(bounds);
+
+            m_vertexBuffer = std::make_unique<VertexBuffer>(sizeof(WallVertex) * m_vertices.size(), sizeof(WallVertex), m_vertices.data());
+            if (!m_vertexBuffer || !m_vertexBuffer->IsValid())
+            {
+                return false;
+            }
+
+            m_rootSignature = std::make_unique<RootSignature>();
+            if (!m_rootSignature || !m_rootSignature->IsValid())
+            {
+                return false;
+            }
+
+            m_pipelineState = std::make_unique<PipelineState>();
+            if (!m_pipelineState)
+            {
+                return false;
+            }
+            D3D12_INPUT_ELEMENT_DESC layout[] =
+            {
+                { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT,    0, offsetof(WallVertex, position), D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+                { "COLOR",    0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, offsetof(WallVertex, color),    D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+            };
+
+            m_pipelineState->SetInputLayout({ layout, _countof(layout) });
+            m_pipelineState->SetRootSignature(m_rootSignature->Get());
+            m_pipelineState->SetVS(L"ColorOnlyVS.cso");
+            m_pipelineState->SetPS(L"ColorOnlyPS.cso");
+            m_pipelineState->SetDepthStencilFormat(DXGI_FORMAT_D32_FLOAT);
+            m_pipelineState->Create(D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE);
+            if (!m_pipelineState->IsValid())
+            {
+                return false;
+            }
+
+            for (auto& cb : m_constantBuffers)
+            {
+                cb = std::make_unique<ConstantBuffer>(sizeof(WallConstant));
+                if (!cb || !cb->IsValid())
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        void Update(const FluidSystem::Bounds& bounds, const Camera& camera)
+        {
+            if (bounds.min.x != m_cachedBounds.min.x || bounds.min.y != m_cachedBounds.min.y ||
+                bounds.min.z != m_cachedBounds.min.z || bounds.max.x != m_cachedBounds.max.x ||
+                bounds.max.y != m_cachedBounds.max.y || bounds.max.z != m_cachedBounds.max.z)
+            {
+                m_cachedBounds = bounds;
+                BuildVertices(bounds);
+                if (m_vertexBuffer)
+                {
+                    void* mapped = nullptr;
+                    auto resource = m_vertexBuffer->GetResource();
+                    if (resource && SUCCEEDED(resource->Map(0, nullptr, &mapped)))
+                    {
+                        memcpy(mapped, m_vertices.data(), sizeof(WallVertex) * m_vertices.size());
+                        resource->Unmap(0, nullptr);
+                    }
+                }
+            }
+
+            UINT frameIndex = g_Engine->CurrentBackBufferIndex();
+            auto& cb = m_constantBuffers[frameIndex];
+            if (!cb)
+            {
+                return;
+            }
+            WallConstant* constant = cb->GetPtr<WallConstant>();
+            XMStoreFloat4x4(&constant->view, XMMatrixTranspose(camera.GetViewMatrix()));
+            XMStoreFloat4x4(&constant->proj, XMMatrixTranspose(camera.GetProjMatrix()));
+        }
+
+        void Render(ID3D12GraphicsCommandList* cmd)
+        {
+            if (!cmd || !m_vertexBuffer || !m_pipelineState || !m_rootSignature)
+            {
+                return;
+            }
+
+            UINT frameIndex = g_Engine->CurrentBackBufferIndex();
+            auto& cb = m_constantBuffers[frameIndex];
+            if (!cb)
+            {
+                return;
+            }
+
+            cmd->SetGraphicsRootSignature(m_rootSignature->Get());
+            cmd->SetPipelineState(m_pipelineState->Get());
+            cmd->SetGraphicsRootConstantBufferView(0, cb->GetAddress());
+
+            auto vbView = m_vertexBuffer->View();
+            cmd->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+            cmd->IASetVertexBuffers(0, 1, &vbView);
+            cmd->DrawInstanced(static_cast<UINT>(m_vertices.size()), 1, 0, 0);
+        }
+
+    private:
+        void BuildVertices(const FluidSystem::Bounds& bounds)
+        {
+            m_vertices.clear();
+            const XMFLOAT4 wallColor{ 0.2f, 0.6f, 1.0f, 0.18f }; // 透明感を表現する薄い色
+            auto addQuad = [this, &wallColor](const XMFLOAT3& a, const XMFLOAT3& b, const XMFLOAT3& c, const XMFLOAT3& d)
+            {
+                m_vertices.push_back({ a, wallColor });
+                m_vertices.push_back({ b, wallColor });
+                m_vertices.push_back({ c, wallColor });
+                m_vertices.push_back({ a, wallColor });
+                m_vertices.push_back({ c, wallColor });
+                m_vertices.push_back({ d, wallColor });
+            };
+
+            const float minX = bounds.min.x;
+            const float maxX = bounds.max.x;
+            const float minY = bounds.min.y;
+            const float maxY = bounds.max.y;
+            const float minZ = bounds.min.z;
+            const float maxZ = bounds.max.z;
+
+            addQuad({ minX, minY, maxZ }, { minX, maxY, maxZ }, { minX, maxY, minZ }, { minX, minY, minZ }); // 左壁
+            addQuad({ maxX, minY, minZ }, { maxX, maxY, minZ }, { maxX, maxY, maxZ }, { maxX, minY, maxZ }); // 右壁
+            addQuad({ minX, minY, minZ }, { minX, maxY, minZ }, { maxX, maxY, minZ }, { maxX, minY, minZ }); // 奥壁
+            addQuad({ maxX, minY, maxZ }, { maxX, maxY, maxZ }, { minX, maxY, maxZ }, { minX, minY, maxZ }); // 手前壁
+        }
+
+        std::vector<WallVertex> m_vertices;
+        FluidSystem::Bounds m_cachedBounds{};
+        std::unique_ptr<VertexBuffer> m_vertexBuffer;
+        std::unique_ptr<RootSignature> m_rootSignature;
+        std::unique_ptr<PipelineState> m_pipelineState;
+        std::array<std::unique_ptr<ConstantBuffer>, Engine::FRAME_BUFFER_COUNT> m_constantBuffers;
+    };
 }
+
+using GameSceneDetail::TransparentWalls;
 
 GameScene::GameScene(Game* game)
     : BaseScene(game)
 {
+    m_initialBounds.min = XMFLOAT3(-2.0f, 0.0f, -2.0f);
+    m_initialBounds.max = XMFLOAT3(2.0f, 2.5f, 2.0f);
 }
 
 GameScene::~GameScene() = default;
 
 bool GameScene::Init()
 {
-    // === カメラ初期化 ===
     auto* camera = new Camera();
     g_Engine->RegisterObj<Camera>("Camera", camera);
 
-    // === 流体系初期化 ===
     m_fluid = std::make_unique<FluidSystem>();
-    if (!m_fluid)
+    if (!m_fluid || !m_fluid->Init(g_Engine->Device(), m_initialBounds, 10000))
     {
         return false;
     }
 
-    m_fluid->Init(g_Engine->Device(), kBackBufferFormat, 512, 128);
-    m_fluid->UseGPU(false); // 安定性を優先してCPUでシミュレーション
-    m_fluid->SetSimulationBounds(XMFLOAT3(-2.0f, 0.0f, -2.0f), XMFLOAT3(2.0f, 3.0f, 2.0f));
-    m_fluid->SetWaterAppearance(
-        XMFLOAT3(0.25f, 0.55f, 0.95f), // 浅い部分の色
-        XMFLOAT3(0.07f, 0.22f, 0.38f), // 深い部分の色
-        0.35f,                         // 吸収率
-        0.45f,                         // 泡のしきい値
-        0.38f,                         // 泡の強さ
-        0.65f,                         // 反射率
-        96.0f);                        // スペキュラ強度
-
-    InitializeStageGeometry();
-
-    // === ルートシグネチャとPSOの生成 ===
-    m_colorRootSignature = std::make_unique<RootSignature>();
-    if (!m_colorRootSignature || !m_colorRootSignature->IsValid())
+    m_walls = std::make_unique<TransparentWalls>();
+    if (!m_walls || !m_walls->Init(m_initialBounds))
     {
         return false;
     }
 
-    static const D3D12_INPUT_ELEMENT_DESC kColorInputLayout[] =
-    {
-        { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, offsetof(ColorVertex, position), D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-        { "COLOR",    0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, offsetof(ColorVertex, color),    D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
-    };
-
-    m_stagePipeline = std::make_unique<PipelineState>();
-    m_stagePipeline->SetInputLayout({ kColorInputLayout, _countof(kColorInputLayout) });
-    m_stagePipeline->SetRootSignature(m_colorRootSignature->Get());
-    m_stagePipeline->SetVS(L"ColorOnlyVS.cso");
-    m_stagePipeline->SetPS(L"ColorOnlyPS.cso");
-    m_stagePipeline->SetDepthStencilFormat(DXGI_FORMAT_D32_FLOAT);
-    m_stagePipeline->Create(D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE);
-    if (!m_stagePipeline->IsValid())
+    m_debugCube = std::make_unique<DebugCube>();
+    if (!m_debugCube)
     {
         return false;
     }
-
-    m_splashPipeline = std::make_unique<PipelineState>();
-    m_splashPipeline->SetInputLayout({ kColorInputLayout, _countof(kColorInputLayout) });
-    m_splashPipeline->SetRootSignature(m_colorRootSignature->Get());
-    m_splashPipeline->SetVS(L"ColorOnlyVS.cso");
-    m_splashPipeline->SetPS(L"ColorOnlyPS.cso");
-    m_splashPipeline->SetDepthStencilFormat(DXGI_FORMAT_D32_FLOAT);
-    m_splashPipeline->Create(D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE);
-    if (!m_splashPipeline->IsValid())
-    {
-        return false;
-    }
-
-    // === 定数バッファ確保 ===
-    for (auto& cb : m_colorCB)
-    {
-        cb = std::make_unique<ConstantBuffer>(sizeof(ColorPassCB));
-        if (!cb || !cb->IsValid())
-        {
-            return false;
-        }
-    }
-
-    // === ステージ頂点バッファの生成 ===
-    if (!m_stageVertices.empty())
-    {
-        m_stageVB = std::make_unique<VertexBuffer>(
-            sizeof(ColorVertex) * m_stageVertices.size(),
-            sizeof(ColorVertex),
-            m_stageVertices.data());
-        if (!m_stageVB || !m_stageVB->IsValid())
-        {
-            return false;
-        }
-        m_stageVertexCount = static_cast<UINT>(m_stageVertices.size());
-    }
+    XMFLOAT3 center{
+        (m_initialBounds.min.x + m_initialBounds.max.x) * 0.5f,
+        m_initialBounds.min.y + 0.3f,
+        (m_initialBounds.min.z + m_initialBounds.max.z) * 0.5f };
+    m_debugCube->SetWorldMatrix(XMMatrixScaling(0.4f, 0.4f, 0.4f) * XMMatrixTranslation(center.x, center.y, center.z));
 
     return true;
 }
 
-void GameScene::InitializeStageGeometry()
+void GameScene::HandleWallControl(Camera& camera, float deltaTime)
 {
-    m_stageVertices.clear();
-    auto addQuad = [this](const XMFLOAT3& a, const XMFLOAT3& b, const XMFLOAT3& c, const XMFLOAT3& d, const XMFLOAT4& color)
+    if (!(GetAsyncKeyState(VK_LBUTTON) & 0x8000))
     {
-        m_stageVertices.push_back({ a, color });
-        m_stageVertices.push_back({ b, color });
-        m_stageVertices.push_back({ c, color });
-        m_stageVertices.push_back({ a, color });
-        m_stageVertices.push_back({ c, color });
-        m_stageVertices.push_back({ d, color });
-    };
+        return;
+    }
 
-    const XMFLOAT4 floorColor{ 0.25f, 0.35f, 0.42f, 1.0f };
-    const XMFLOAT4 wallColor{ 0.18f, 0.22f, 0.28f, 1.0f };
-    const float minX = -2.0f;
-    const float maxX = 2.0f;
-    const float minZ = -2.0f;
-    const float maxZ = 2.0f;
-    const float maxY = 2.0f;
+    XMVECTOR forward = XMVector3Normalize(XMVectorSubtract(camera.GetTargetPos(), camera.GetEyePos()));
+    forward = XMVectorSet(XMVectorGetX(forward), 0.0f, XMVectorGetZ(forward), 0.0f);
+    if (XMVector3LengthSq(forward).m128_f32[0] < 1e-6f)
+    {
+        forward = XMVectorSet(0.0f, 0.0f, 1.0f, 0.0f);
+    }
+    forward = XMVector3Normalize(forward);
 
-    // 床
-    addQuad(
-        XMFLOAT3(minX, 0.0f, minZ),
-        XMFLOAT3(maxX, 0.0f, minZ),
-        XMFLOAT3(maxX, 0.0f, maxZ),
-        XMFLOAT3(minX, 0.0f, maxZ),
-        floorColor);
+    XMVECTOR right = XMVector3Cross(forward, XMVectorSet(0.0f, 1.0f, 0.0f, 0.0f));
+    if (XMVector3LengthSq(right).m128_f32[0] < 1e-6f)
+    {
+        right = XMVectorSet(1.0f, 0.0f, 0.0f, 0.0f);
+    }
+    right = XMVector3Normalize(right);
 
-    // 壁（左）
-    addQuad(
-        XMFLOAT3(minX, 0.0f, maxZ),
-        XMFLOAT3(minX, maxY, maxZ),
-        XMFLOAT3(minX, maxY, minZ),
-        XMFLOAT3(minX, 0.0f, minZ),
-        wallColor);
+    XMVECTOR move = XMVectorZero();
+    if (GetAsyncKeyState('W') & 0x8000) move = XMVectorAdd(move, forward);
+    if (GetAsyncKeyState('S') & 0x8000) move = XMVectorSubtract(move, forward);
+    if (GetAsyncKeyState('D') & 0x8000) move = XMVectorAdd(move, right);
+    if (GetAsyncKeyState('A') & 0x8000) move = XMVectorSubtract(move, right);
 
-    // 壁（右）
-    addQuad(
-        XMFLOAT3(maxX, 0.0f, minZ),
-        XMFLOAT3(maxX, maxY, minZ),
-        XMFLOAT3(maxX, maxY, maxZ),
-        XMFLOAT3(maxX, 0.0f, maxZ),
-        wallColor);
+    if (XMVector3LengthSq(move).m128_f32[0] < 1e-6f)
+    {
+        return;
+    }
 
-    // 壁（奥）
-    addQuad(
-        XMFLOAT3(minX, 0.0f, minZ),
-        XMFLOAT3(minX, maxY, minZ),
-        XMFLOAT3(maxX, maxY, minZ),
-        XMFLOAT3(maxX, 0.0f, minZ),
-        wallColor);
+    move = XMVector3Normalize(move) * (m_wallMoveSpeed * deltaTime);
+    XMFLOAT3 delta;
+    XMStoreFloat3(&delta, move);
 
-    // 壁（手前）
-    addQuad(
-        XMFLOAT3(maxX, 0.0f, maxZ),
-        XMFLOAT3(maxX, maxY, maxZ),
-        XMFLOAT3(minX, maxY, maxZ),
-        XMFLOAT3(minX, 0.0f, maxZ),
-        wallColor);
+    if (m_fluid)
+    {
+        m_fluid->MoveBounds(delta);
+    }
 }
 
 void GameScene::Update(float deltaTime)
 {
-    m_deltaTime = deltaTime;
-
-    auto* camera = g_Engine->GetObj<Camera>("Camera");
-    if (camera)
+    Camera* camera = g_Engine->GetObj<Camera>("Camera");
+    if (!camera)
     {
-        camera->Update(deltaTime);
+        return;
     }
+
+    camera->Update(deltaTime);
+    HandleWallControl(*camera, deltaTime);
 
     if (m_fluid)
     {
-        m_fluid->ClearDynamicOperations();
+        m_fluid->Update(deltaTime);
     }
 
-    UpdateGatherOperation(camera);
-    UpdateSplashParticles(deltaTime, camera);
-
-    // デバッグ用途：キー入力でマテリアルを切り替え
-    if (GetAsyncKeyState('1') & 0x0001)
+    if (m_debugCube && m_fluid)
     {
-        m_fluid->SetMaterialPreset(FluidMaterialPreset::Water);
+        const auto& bounds = m_fluid->GetBounds();
+        XMFLOAT3 center{
+            (bounds.min.x + bounds.max.x) * 0.5f,
+            bounds.min.y + 0.3f,
+            (bounds.min.z + bounds.max.z) * 0.5f };
+        m_debugCube->SetWorldMatrix(XMMatrixScaling(0.4f, 0.4f, 0.4f) * XMMatrixTranslation(center.x, center.y, center.z));
+        m_debugCube->Update(deltaTime);
     }
-    if (GetAsyncKeyState('2') & 0x0001)
+
+    if (m_walls && m_fluid)
     {
-        m_fluid->SetMaterialPreset(FluidMaterialPreset::Magma);
+        m_walls->Update(m_fluid->GetBounds(), *camera);
     }
 }
 
@@ -218,407 +300,18 @@ void GameScene::Draw()
         return;
     }
 
-    UpdateCameraConstantBuffer(camera);
-    RenderStage(cmd);
-
-    XMMATRIX view = camera->GetViewMatrix();
-    XMMATRIX proj = camera->GetProjMatrix();
-    XMMATRIX viewProj = XMMatrixMultiply(view, proj);
-    XMFLOAT4X4 viewM, projM, viewProjM;
-    XMStoreFloat4x4(&viewM, view);
-    XMStoreFloat4x4(&projM, proj);
-    XMStoreFloat4x4(&viewProjM, viewProj);
-    XMFLOAT3 cameraPos = camera->GetPosition();
-
     if (m_fluid)
     {
-        m_fluid->Simulate(cmd, m_deltaTime);
-        m_fluid->Render(cmd, viewM, projM, viewProjM, cameraPos, 0.18f);
-        m_fluid->Composite(cmd,
-            g_Engine->CurrentRenderTargetResource(),
-            g_Engine->DepthStencilBuffer(),
-            g_Engine->CurrentBackBufferView());
+        m_fluid->Draw(cmd, *camera);
     }
 
-    SpawnSplashFromCollisions();
-    UploadSplashVertices(camera);
-    RenderSplash(cmd);
-}
-
-void GameScene::UpdateCameraConstantBuffer(const Camera* camera)
-{
-    if (!camera)
+    if (m_walls)
     {
-        return;
-    }
-    UINT frameIndex = g_Engine->CurrentBackBufferIndex();
-    auto& cb = m_colorCB[frameIndex];
-    if (!cb)
-    {
-        return;
+        m_walls->Render(cmd);
     }
 
-    ColorPassCB* data = cb->GetPtr<ColorPassCB>();
-    XMMATRIX view = camera->GetViewMatrix();
-    XMMATRIX proj = camera->GetProjMatrix();
-    XMStoreFloat4x4(&data->view, XMMatrixTranspose(view));
-    XMStoreFloat4x4(&data->proj, XMMatrixTranspose(proj));
-}
-
-void GameScene::RenderStage(ID3D12GraphicsCommandList* cmd)
-{
-    if (!m_stageVB || !m_stagePipeline || !m_colorRootSignature)
+    if (m_debugCube)
     {
-        return;
-    }
-    UINT frameIndex = g_Engine->CurrentBackBufferIndex();
-    auto& cb = m_colorCB[frameIndex];
-    if (!cb)
-    {
-        return;
-    }
-
-    cmd->SetGraphicsRootSignature(m_colorRootSignature->Get());
-    cmd->SetPipelineState(m_stagePipeline->Get());
-    cmd->SetGraphicsRootConstantBufferView(0, cb->GetAddress());
-
-    auto vbView = m_stageVB->View();
-    cmd->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-    cmd->IASetVertexBuffers(0, 1, &vbView);
-    cmd->DrawInstanced(m_stageVertexCount, 1, 0, 0);
-}
-
-void GameScene::RenderSplash(ID3D12GraphicsCommandList* cmd)
-{
-    if (!m_splashVB || !m_splashPipeline || m_splashVertexCount == 0)
-    {
-        return;
-    }
-
-    UINT frameIndex = g_Engine->CurrentBackBufferIndex();
-    auto& cb = m_colorCB[frameIndex];
-    if (!cb)
-    {
-        return;
-    }
-
-    cmd->SetGraphicsRootSignature(m_colorRootSignature->Get());
-    cmd->SetPipelineState(m_splashPipeline->Get());
-    cmd->SetGraphicsRootConstantBufferView(0, cb->GetAddress());
-
-    auto vbView = m_splashVB->View();
-    cmd->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-    cmd->IASetVertexBuffers(0, 1, &vbView);
-    cmd->DrawInstanced(m_splashVertexCount, 1, 0, 0);
-}
-
-void GameScene::UpdateGatherOperation(Camera* camera)
-{
-    if (!m_fluid || !camera)
-    {
-        return;
-    }
-
-    bool leftDown = (GetAsyncKeyState(VK_LBUTTON) & 0x8000) != 0;
-
-    if (leftDown && !m_leftButtonDown)
-    {
-        m_leftButtonDown = BeginGather(camera);
-    }
-    else if (!leftDown && m_leftButtonDown)
-    {
-        ReleaseGather(camera);
-        m_leftButtonDown = false;
-    }
-
-    if (leftDown && m_gatherState.active)
-    {
-        m_gatherState.holdTime += m_deltaTime;
-
-        XMFLOAT3 camPos = camera->GetPosition();
-        XMFLOAT3 target{
-            camPos.x + m_gatherState.cameraOffset.x,
-            camPos.y + m_gatherState.cameraOffset.y,
-            camPos.z + m_gatherState.cameraOffset.z };
-
-        // カメラ前方へ少し押し出して手前にまとまるようにする
-        XMMATRIX invView = XMMatrixInverse(nullptr, camera->GetViewMatrix());
-        XMVECTOR forward = XMVector3Normalize(invView.r[2]);
-        XMFLOAT3 forwardF;
-        XMStoreFloat3(&forwardF, forward);
-        target.x += forwardF.x * 0.2f;
-        target.y += forwardF.y * 0.2f;
-        target.z += forwardF.z * 0.2f;
-
-        float radius = std::clamp(0.35f + 0.25f / (1.0f + m_gatherState.holdTime), 0.2f, 0.6f);
-        float strength = m_gatherState.baseStrength + m_gatherState.holdTime * 6.0f;
-        m_fluid->QueueGather(target, radius, strength);
-
-        // 収束中は揺らぎを抑えるために追加の軽い吸引を入れる
-        m_fluid->QueueGather(target, radius * 0.5f, strength * 0.5f);
+        m_debugCube->Render(cmd);
     }
 }
-
-bool GameScene::BeginGather(Camera* camera)
-{
-    if (!camera || !m_fluid)
-    {
-        return false;
-    }
-
-    POINT cursor;
-    GetCursorPos(&cursor);
-    ScreenToClient(g_hWnd, &cursor);
-
-    XMFLOAT3 origin, direction;
-    if (!ScreenPointToRay(cursor.x, cursor.y, origin, direction))
-    {
-        return false;
-    }
-
-    XMFLOAT3 hitPos;
-    if (!m_fluid->Raycast(origin, direction, kMaxRayDistance, 0.25f, hitPos))
-    {
-        return false;
-    }
-
-    XMFLOAT3 camPos = camera->GetPosition();
-    m_gatherState.active = true;
-    m_gatherState.holdTime = 0.0f;
-    m_gatherState.hitPosition = hitPos;
-    m_gatherState.cameraOffset = XMFLOAT3(
-        hitPos.x - camPos.x,
-        hitPos.y - camPos.y,
-        hitPos.z - camPos.z);
-    m_gatherState.radius = 0.45f;
-    m_gatherState.baseStrength = 14.0f;
-
-    // 初期段階で軽く吸引して集まり始めるようにする
-    m_fluid->QueueGather(hitPos, m_gatherState.radius, m_gatherState.baseStrength);
-
-    return true;
-}
-
-void GameScene::ReleaseGather(Camera* camera)
-{
-    if (!m_fluid || !camera || !m_gatherState.active)
-    {
-        m_gatherState.active = false;
-        return;
-    }
-
-    XMFLOAT3 camPos = camera->GetPosition();
-    XMMATRIX invView = XMMatrixInverse(nullptr, camera->GetViewMatrix());
-    XMVECTOR forwardVec = XMVector3Normalize(invView.r[2]);
-    XMFLOAT3 forward;
-    XMStoreFloat3(&forward, forwardVec);
-
-    XMFLOAT3 center{
-        camPos.x + m_gatherState.cameraOffset.x + forward.x * 0.2f,
-        camPos.y + m_gatherState.cameraOffset.y + forward.y * 0.2f,
-        camPos.z + m_gatherState.cameraOffset.z + forward.z * 0.2f };
-
-    float radius = std::clamp(0.35f + 0.25f / (1.0f + m_gatherState.holdTime), 0.2f, 0.6f);
-    float impulse = 3.5f + m_gatherState.holdTime * 2.0f;
-    float directional = 12.0f + m_gatherState.holdTime * 6.0f;
-
-    m_fluid->QueueDirectionalImpulse(center, radius, forward, directional);
-    m_fluid->QueueSplash(center, radius, impulse);
-
-    m_gatherState.active = false;
-}
-
-bool GameScene::ScreenPointToRay(int mouseX, int mouseY, XMFLOAT3& outOrigin, XMFLOAT3& outDirection) const
-{
-    const Camera* camera = g_Engine->GetObj<Camera>("Camera");
-    if (!camera)
-    {
-        return false;
-    }
-
-    float width = static_cast<float>(g_Engine->FrameBufferWidth());
-    float height = static_cast<float>(g_Engine->FrameBufferHeight());
-    float ndcX = (2.0f * mouseX / width) - 1.0f;
-    float ndcY = -((2.0f * mouseY / height) - 1.0f);
-
-    XMMATRIX view = camera->GetViewMatrix();
-    XMMATRIX proj = camera->GetProjMatrix();
-    XMMATRIX invViewProj = XMMatrixInverse(nullptr, XMMatrixMultiply(view, proj));
-    XMVECTOR nearPoint = XMVectorSet(ndcX, ndcY, 0.0f, 1.0f);
-    XMVECTOR farPoint = XMVectorSet(ndcX, ndcY, 1.0f, 1.0f);
-
-    nearPoint = XMVector3TransformCoord(nearPoint, invViewProj);
-    farPoint = XMVector3TransformCoord(farPoint, invViewProj);
-
-    XMVECTOR rayDir = XMVector3Normalize(XMVectorSubtract(farPoint, nearPoint));
-    XMStoreFloat3(&outOrigin, nearPoint);
-    XMStoreFloat3(&outDirection, rayDir);
-    return true;
-}
-
-void GameScene::SpawnSplashFromCollisions()
-{
-    if (!m_fluid)
-    {
-        return;
-    }
-
-    std::vector<FluidCollisionEvent> events;
-    m_fluid->PopCollisionEvents(events);
-    if (events.empty())
-    {
-        return;
-    }
-
-    static std::mt19937 rng{ std::random_device{}() };
-    std::uniform_real_distribution<float> random01(0.0f, 1.0f);
-
-    for (const auto& evt : events)
-    {
-        if (evt.strength < 0.5f)
-        {
-            continue;
-        }
-
-        const int spawnCount = std::clamp(static_cast<int>(evt.strength * 0.4f), 2, 6);
-        XMVECTOR normal = XMLoadFloat3(&evt.normal);
-
-        for (int i = 0; i < spawnCount; ++i)
-        {
-            SplashParticle particle{};
-            particle.position = evt.position;
-            particle.age = 0.0f;
-            particle.lifetime = 0.45f + random01(rng) * 0.35f;
-            particle.initialStrength = evt.strength;
-            particle.size = 0.18f + evt.strength * 0.05f;
-
-            float spread = 0.5f + random01(rng) * 0.6f;
-            float speed = evt.strength * (0.45f + random01(rng) * 0.25f);
-
-            // 法線方向をベースに少し散らばるよう乱数を加える
-            XMVECTOR tangent = XMVector3Normalize(XMVectorSet(random01(rng) * 2.0f - 1.0f, 0.0f, random01(rng) * 2.0f - 1.0f, 0.0f));
-            XMVECTOR side = XMVector3Normalize(XMVector3Cross(normal, tangent));
-            XMVECTOR velocity = XMVectorAdd(XMVectorScale(normal, speed), XMVectorScale(side, spread));
-            XMStoreFloat3(&particle.velocity, velocity);
-
-            m_splashParticles.push_back(particle);
-        }
-    }
-}
-
-void GameScene::UpdateSplashParticles(float deltaTime, const Camera* /*camera*/)
-{
-    if (m_splashParticles.empty())
-    {
-        return;
-    }
-
-    const XMFLOAT3 gravity{ 0.0f, -9.8f, 0.0f };
-    for (auto& particle : m_splashParticles)
-    {
-        particle.velocity.x += gravity.x * deltaTime;
-        particle.velocity.y += gravity.y * deltaTime;
-        particle.velocity.z += gravity.z * deltaTime;
-
-        particle.position.x += particle.velocity.x * deltaTime;
-        particle.position.y += particle.velocity.y * deltaTime;
-        particle.position.z += particle.velocity.z * deltaTime;
-
-        particle.age += deltaTime;
-    }
-
-    m_splashParticles.erase(
-        std::remove_if(m_splashParticles.begin(), m_splashParticles.end(), [](const SplashParticle& p)
-            {
-                return p.age >= p.lifetime;
-            }),
-        m_splashParticles.end());
-}
-
-void GameScene::UploadSplashVertices(const Camera* camera)
-{
-    if (!camera)
-    {
-        return;
-    }
-
-    if (m_splashParticles.empty())
-    {
-        m_splashVertexCount = 0;
-        return;
-    }
-
-    const size_t vertexPerParticle = 6;
-    size_t requiredVertices = m_splashParticles.size() * vertexPerParticle;
-    if (!m_splashVB || m_splashVertexCapacity < requiredVertices)
-    {
-        m_splashVB = std::make_unique<VertexBuffer>(
-            sizeof(ColorVertex) * requiredVertices,
-            sizeof(ColorVertex),
-            nullptr);
-        if (!m_splashVB || !m_splashVB->IsValid())
-        {
-            m_splashVertexCount = 0;
-            m_splashVertexCapacity = 0;
-            return;
-        }
-        m_splashVertexCapacity = requiredVertices;
-    }
-
-    std::vector<ColorVertex> vertices(requiredVertices);
-
-    XMMATRIX invView = XMMatrixInverse(nullptr, camera->GetViewMatrix());
-    XMVECTOR right = XMVector3Normalize(invView.r[0]);
-    XMVECTOR up = XMVector3Normalize(invView.r[1]);
-
-    size_t v = 0;
-    for (const auto& particle : m_splashParticles)
-    {
-        float lifeRatio = std::clamp(particle.age / particle.lifetime, 0.0f, 1.0f);
-        float alpha = std::clamp(1.0f - lifeRatio, 0.0f, 1.0f);
-        float size = particle.size * (0.6f + 0.4f * (1.0f - lifeRatio));
-
-        XMVECTOR center = XMLoadFloat3(&particle.position);
-        XMVECTOR halfRight = XMVectorScale(right, size);
-        XMVECTOR halfUp = XMVectorScale(up, size);
-
-        XMVECTOR corners[4];
-        corners[0] = XMVectorSubtract(XMVectorSubtract(center, halfRight), halfUp);
-        corners[1] = XMVectorAdd(XMVectorSubtract(center, halfUp), halfRight);
-        corners[2] = XMVectorAdd(center, XMVectorAdd(halfRight, halfUp));
-        corners[3] = XMVectorSubtract(XMVectorAdd(center, halfUp), halfRight);
-
-        XMFLOAT4 color{
-            0.4f + 0.3f * (particle.initialStrength * 0.05f),
-            0.7f + 0.2f * (1.0f - lifeRatio),
-            1.0f,
-            alpha * 0.85f };
-
-        XMStoreFloat3(&vertices[v + 0].position, corners[0]);
-        vertices[v + 0].color = color;
-        XMStoreFloat3(&vertices[v + 1].position, corners[1]);
-        vertices[v + 1].color = color;
-        XMStoreFloat3(&vertices[v + 2].position, corners[2]);
-        vertices[v + 2].color = color;
-        XMStoreFloat3(&vertices[v + 3].position, corners[0]);
-        vertices[v + 3].color = color;
-        XMStoreFloat3(&vertices[v + 4].position, corners[2]);
-        vertices[v + 4].color = color;
-        XMStoreFloat3(&vertices[v + 5].position, corners[3]);
-        vertices[v + 5].color = color;
-        v += vertexPerParticle;
-    }
-
-    void* mapped = nullptr;
-    if (SUCCEEDED(m_splashVB->GetResource()->Map(0, nullptr, &mapped)) && mapped)
-    {
-        std::memcpy(mapped, vertices.data(), sizeof(ColorVertex) * vertices.size());
-        m_splashVB->GetResource()->Unmap(0, nullptr);
-        m_splashVertexCount = static_cast<UINT>(vertices.size());
-    }
-    else
-    {
-        m_splashVertexCount = 0;
-    }
-}
-

--- a/DirectX12/GameScene.h
+++ b/DirectX12/GameScene.h
@@ -1,20 +1,14 @@
 #pragma once
 #include "BaseScene.h"
 #include "FluidSystem.h"
-#include "ConstantBuffer.h"
-#include "VertexBuffer.h"
-#include "RootSignature.h"
-#include "PipelineState.h"
-#include "DescriptorHeap.h"
-#include "Camera.h"
-#include "Engine.h"
 #include <DirectXMath.h>
-#include <Windows.h>
-#include <array>
 #include <memory>
-#include <vector>
 
-// ゲームメインシーン。流体シミュレーションの制御と描画を担当する。
+class Camera;
+class DebugCube;
+namespace GameSceneDetail { class TransparentWalls; }
+
+// ゲームシーン。流体・壁・デバッグオブジェクトの管理のみを行う。
 class GameScene : public BaseScene
 {
 public:
@@ -26,68 +20,13 @@ public:
     void Draw() override;
 
 private:
-    struct GatherState
-    {
-        bool active = false;                 // 集水中かどうか
-        float holdTime = 0.0f;               // ボタンを押し続けている時間
-        DirectX::XMFLOAT3 hitPosition{};     // レイキャストでヒットした初期位置
-        DirectX::XMFLOAT3 cameraOffset{};    // カメラからのオフセット（カメラを動かしたときに追従させる）
-        float radius = 0.5f;                 // 集水半径
-        float baseStrength = 12.0f;          // 集水強度の初期値
-    };
+    std::unique_ptr<FluidSystem> m_fluid;        // 流体本体
+    std::unique_ptr<DebugCube> m_debugCube;      // デバッグ用キューブ
 
-    struct SplashParticle
-    {
-        DirectX::XMFLOAT3 position;          // 現在位置
-        DirectX::XMFLOAT3 velocity;          // 移動速度
-        float age = 0.0f;                    // 経過時間
-        float lifetime = 0.6f;               // 寿命
-        float size = 0.18f;                  // ビルボードサイズ
-        float initialStrength = 1.0f;        // 生成時の強さ（色と速度の調整に使用）
-    };
+    std::unique_ptr<GameSceneDetail::TransparentWalls> m_walls; // 透明な壁描画用
 
-    struct ColorVertex
-    {
-        DirectX::XMFLOAT3 position;          // 頂点座標
-        DirectX::XMFLOAT4 color;             // 頂点カラー
-    };
+    FluidSystem::Bounds m_initialBounds{}; // 初期境界情報
+    float m_wallMoveSpeed = 1.5f;          // 壁移動速度
 
-    struct ColorPassCB
-    {
-        DirectX::XMFLOAT4X4 view;            // ビュー行列（転置済み）
-        DirectX::XMFLOAT4X4 proj;            // プロジェクション行列（転置済み）
-    };
-
-    std::unique_ptr<FluidSystem> m_fluid;                     // 流体系本体
-    GatherState                   m_gatherState;              // 集水操作の状態
-    float                         m_deltaTime = 0.0f;         // 最新のデルタタイム
-    std::vector<SplashParticle>   m_splashParticles;          // 水しぶき用パーティクル
-    std::vector<ColorVertex>      m_stageVertices;            // 簡易ステージの頂点
-
-    std::unique_ptr<VertexBuffer> m_stageVB;                  // ステージ描画用頂点バッファ
-    UINT                          m_stageVertexCount = 0;     // ステージ頂点数
-
-    std::unique_ptr<VertexBuffer> m_splashVB;                 // 水しぶき用頂点バッファ
-    UINT                          m_splashVertexCount = 0;    // 現在アップロードされている水しぶき頂点数
-    size_t                        m_splashVertexCapacity = 0; // バッファが保持できる頂点数
-
-    std::unique_ptr<RootSignature> m_colorRootSignature;      // カラー表示用ルートシグネチャ
-    std::unique_ptr<PipelineState> m_stagePipeline;           // ステージ描画用PSO
-    std::unique_ptr<PipelineState> m_splashPipeline;          // 水しぶき描画用PSO
-    std::array<std::unique_ptr<ConstantBuffer>, Engine::FRAME_BUFFER_COUNT> m_colorCB; // ビュー射影行列
-
-    bool  m_leftButtonDown = false;                           // 左クリック押下状態
-
-    void InitializeStageGeometry();
-    void UpdateCameraConstantBuffer(const Camera* camera);
-    void UpdateGatherOperation(Camera* camera);
-    void SpawnSplashFromCollisions();
-    void UpdateSplashParticles(float deltaTime, const Camera* camera);
-    void UploadSplashVertices(const Camera* camera);
-    void RenderStage(ID3D12GraphicsCommandList* cmd);
-    void RenderSplash(ID3D12GraphicsCommandList* cmd);
-    bool ScreenPointToRay(int mouseX, int mouseY, DirectX::XMFLOAT3& outOrigin, DirectX::XMFLOAT3& outDirection) const;
-    bool BeginGather(Camera* camera);
-    void ReleaseGather(Camera* camera);
+    void HandleWallControl(Camera& camera, float deltaTime);
 };
-


### PR DESCRIPTION
## Summary
- replace the previous FluidSystem with a lightweight CPU particle simulator that renders 10k point sprites inside configurable bounds
- simplify GameScene to manage the fluid, transparent wall visualization, and a debug cube while allowing left-click WASD wall movement
- update the camera and debug cube helpers to support the new interaction model

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4772ca3c08332af5352feb5525e4a