### PR TITLE
Render fluid particles as instanced spheres and visualize grid

### DIFF
--- a/DirectX12/FluidSystem.h
+++ b/DirectX12/FluidSystem.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "ConstantBuffer.h"
 #include "Engine.h"
+#include "IndexBuffer.h"
 #include "PipelineState.h"
 #include "RootSignature.h"
 #include "SharedStruct.h"
@@ -50,14 +51,41 @@ private:
 
     void InitializeParticles(UINT particleCount);
     void ResolveCollisions(Particle& particle) const;
-    void UpdateVertexBuffer();
+    void UpdateInstanceBuffer();
+    void UpdateGridLines();
+
+    struct SphereVertex
+    {
+        DirectX::XMFLOAT3 position; // 球メッシュの頂点位置
+        DirectX::XMFLOAT3 normal;   // 球メッシュの法線
+    };
+
+    struct ParticleInstance
+    {
+        DirectX::XMFLOAT3 position; // 粒子中心位置
+        float radius;               // 描画半径
+    };
+
+    struct GridLineVertex
+    {
+        DirectX::XMFLOAT3 position; // グリッド境界線の頂点位置
+    };
 
     std::vector<Particle> m_particles;               // 流体粒子
-    std::vector<ParticleVertex> m_renderVertices;    // 描画用頂点
-    std::unique_ptr<VertexBuffer> m_vertexBuffer;    // 粒子描画用VB
+    std::vector<ParticleInstance> m_instances;       // インスタンシング用データ
+    std::unique_ptr<VertexBuffer> m_instanceBuffer;  // 粒子描画用インスタンスVB
+    std::unique_ptr<VertexBuffer> m_sphereVertexBuffer; // 球メッシュ頂点VB
+    std::unique_ptr<IndexBuffer> m_sphereIndexBuffer;   // 球メッシュIB
+    UINT m_indexCount = 0;                              // 球メッシュのインデックス数
     std::unique_ptr<RootSignature> m_rootSignature;  // 粒子描画用ルートシグネチャ
     std::unique_ptr<PipelineState> m_pipelineState;  // 粒子描画用PSO
+    std::unique_ptr<PipelineState> m_gridPipelineState; // グリッド描画用PSO
     std::array<std::unique_ptr<ConstantBuffer>, Engine::FRAME_BUFFER_COUNT> m_constantBuffers; // 定数バッファ
+
+    std::vector<GridLineVertex> m_gridLineVertices;  // グリッド線分頂点
+    std::unique_ptr<VertexBuffer> m_gridLineBuffer;   // グリッド線分用VB
+    size_t m_gridLineCapacity = 0;                    // グリッド線分VBの収容数
+    UINT m_gridLineVertexCount = 0;                   // 描画に使用する頂点数
 
     Bounds m_bounds{};             // 現在の境界
     DirectX::XMMATRIX m_world;     // 粒子全体のワールド行列

--- a/DirectX12/GridLinePS.hlsl
+++ b/DirectX12/GridLinePS.hlsl
@@ -1,0 +1,10 @@
+struct VSOutput
+{
+    float4 svpos : SV_POSITION;
+};
+
+float4 main(VSOutput input) : SV_TARGET
+{
+    (void)input;
+    return float4(1.0f, 0.85f, 0.2f, 1.0f); // グリッド境界は視認しやすい暖色で描画
+}

--- a/DirectX12/GridLineVS.hlsl
+++ b/DirectX12/GridLineVS.hlsl
@@ -1,0 +1,25 @@
+cbuffer Transform : register(b0)
+{
+    float4x4 World;
+    float4x4 View;
+    float4x4 Proj;
+}
+
+struct VSInput
+{
+    float3 position : POSITION;
+};
+
+struct VSOutput
+{
+    float4 svpos : SV_POSITION;
+};
+
+VSOutput main(VSInput input)
+{
+    VSOutput output;
+    float4 worldPos = mul(World, float4(input.position, 1.0f)); // ワールド行列で格子線の位置をそろえる
+    float4 viewPos = mul(View, worldPos);
+    output.svpos = mul(Proj, viewPos);
+    return output;
+}

--- a/DirectX12/ParticlePS.hlsl
+++ b/DirectX12/ParticlePS.hlsl
@@ -1,11 +1,18 @@
 struct VSOutput
 {
-    float4 Position : SV_POSITION;
-    float4 Color    : COLOR;
+    float4 svpos   : SV_POSITION;
+    float3 normal  : NORMAL;
+    float3 worldPos : TEXCOORD0;
 };
 
 float4 PSMain(VSOutput input) : SV_TARGET
 {
-    // VSから受け取った色をそのまま出力するだけのシンプルなPS
-    return input.Color;
+    const float3 lightDir = normalize(float3(0.3f, 0.8f, 0.4f)); // 粒子を立体的に見せる簡易平行光源
+    const float3 baseColor = float3(0.2f, 0.6f, 1.0f);
+
+    float diffuse = saturate(dot(normalize(input.normal), lightDir));
+    float ambient = 0.25f;
+    float lighting = ambient + diffuse * 0.75f;
+
+    return float4(baseColor * lighting, 1.0f);
 }

--- a/DirectX12/ParticleVS.hlsl
+++ b/DirectX12/ParticleVS.hlsl
@@ -7,22 +7,30 @@ cbuffer Transform : register(b0)
 
 struct VSInput
 {
-    float3 pos : POSITION;
+    float3 localPos : POSITION0;
+    float3 localNormal : NORMAL0;
+    float3 instancePos : POSITION1;
+    float  instanceRadius : TEXCOORD0;
 };
 
 struct VSOutput
 {
-    float4 pos : SV_POSITION;
-    float4 color : COLOR;
+    float4 svpos   : SV_POSITION;
+    float3 normal  : NORMAL;
+    float3 worldPos : TEXCOORD0;
 };
 
 
 VSOutput VSMain(VSInput input)
 {
     VSOutput output;
-    float4 worldPos = mul(World, float4(input.pos, 1.0f));
+    float3 scaledPos = input.localPos * input.instanceRadius; // 影響半径に合わせて球を拡大
+    float4 worldPos = mul(World, float4(input.instancePos + scaledPos, 1.0f)); // 粒子の中心へ平行移動
     float4 viewPos = mul(View, worldPos);
-    output.pos = mul(Proj, viewPos);
-    output.color = float4(0.2, 0.6, 1.0, 1.0);
+    output.svpos = mul(Proj, viewPos);
+
+    float3x3 world3x3 = (float3x3)World;
+    output.normal = normalize(mul(world3x3, input.localNormal)); // 法線もワールドへ変換
+    output.worldPos = worldPos.xyz;
     return output;
 }

--- a/DirectX12/SpatialGrid.cpp
+++ b/DirectX12/SpatialGrid.cpp
@@ -39,3 +39,16 @@ void SpatialGrid::Query(const DirectX::XMFLOAT3& center, float radius, std::vect
         }
     }
 }
+
+void SpatialGrid::CollectActiveCellMins(std::vector<DirectX::XMFLOAT3>& outCellMins) const {
+    outCellMins.clear();
+    outCellMins.reserve(m_cells.size());
+    for (const auto& cell : m_cells) {
+        const Int3& key = cell.first;
+        DirectX::XMFLOAT3 minCorner{
+            static_cast<float>(key.x) * m_cellSize,
+            static_cast<float>(key.y) * m_cellSize,
+            static_cast<float>(key.z) * m_cellSize };
+        outCellMins.push_back(minCorner); // グリッド境界の最小点を保持して描画ライン生成に使う
+    }
+}

--- a/DirectX12/SpatialGrid.h
+++ b/DirectX12/SpatialGrid.h
@@ -12,6 +12,7 @@ public:
     float CellSize() const { return m_cellSize; }
     void Insert(size_t index, const DirectX::XMFLOAT3& pos);
     void Query(const DirectX::XMFLOAT3& center, float radius, std::vector<size_t>& results) const;
+    void CollectActiveCellMins(std::vector<DirectX::XMFLOAT3>& outCellMins) const;
 
 private:
     struct Int3 {


### PR DESCRIPTION
## Summary
- replace point sprite rendering with instanced sphere meshes sized to each particle's support radius
- refresh the fluid instance buffer and draw the spatial grid's active cell boundaries as line segments
- document the neighbor search cost and reuse the existing grid data to explain the performance behavior

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e48770104c8332829f8af1ae5b0397