### PR TITLE
Refactor fluid system to MLS-MPM grid and adjust SSFR radius

### DIFF
--- a/DirectX12/FluidSystem.h
+++ b/DirectX12/FluidSystem.h
@@ -5,7 +5,6 @@
 #include "PipelineState.h"
 #include "RootSignature.h"
 #include "SharedStruct.h"
-#include "SpatialGrid.h"
 #include "VertexBuffer.h"
 #include <DirectXMath.h>
 #include <array>
@@ -53,6 +52,10 @@ private:
     void ResolveCollisions(Particle& particle) const;
     void UpdateInstanceBuffer();
     void UpdateGridLines();
+    void InitializeGrid();
+    void ClearGridNodes();
+    size_t GridIndex(int x, int y, int z) const;
+    void EnsureGridReady();
 
     struct SphereVertex
     {
@@ -93,10 +96,17 @@ private:
     float m_restitution = 0.4f;     // 壁衝突時の反発係数
     float m_drag = 0.1f;            // 簡易減衰係数
     float m_supportRadius = 0.18f;  // 粒子同士の相互作用半径
-    float m_interactionStrength = 8.0f; // 粒子押し戻し力の係数
     float m_maxVelocity = 6.0f;     // 速度クランプ値
 
-    SpatialGrid m_grid;                                     // 近傍探索用グリッド
-    std::vector<size_t> m_neighborIndices;                 // 近傍粒子インデックス一時バッファ
-    std::vector<DirectX::XMFLOAT3> m_neighborForces;       // 粒子間相互作用の蓄積結果
+    struct GridNode
+    {
+        DirectX::XMFLOAT3 velocity; // 節点速度（粒子の重心速度を蓄積）
+        float mass;                 // 節点質量（MLS-MPM での重み合計）
+    };
+
+    DirectX::XMFLOAT3 m_gridOrigin{ 0.0f, 0.0f, 0.0f }; // グリッド原点
+    DirectX::XMINT3 m_gridResolution{ 1, 1, 1 };        // グリッド解像度
+    float m_gridSpacing = 0.1f;                         // グリッドセル間隔
+    std::vector<GridNode> m_gridNodes;                  // MLS-MPM 用の節点データ
+    float m_ssfrResolutionScale = 0.5f;                 // SSFR を半解像度で回すスケール
 };


### PR DESCRIPTION
## Summary
- rework `FluidSystem` to scatter and gather particle data on an MLS-MPM style background grid instead of performing neighbor searches each frame
- add helpers to initialize, clear, and index the simulation grid while disabling the obsolete debug grid rendering
- widen the particle instance radius so the sphere mesh covers half-resolution SSFR targets without visual gaps

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4a53736548332b25d79c110272f95