### PR TITLE
Fix SSFR viewport and SRV binding issues

### DIFF
--- a/DirectX12/FluidSystem.h
+++ b/DirectX12/FluidSystem.h
@@ -159,7 +159,6 @@ private:
     UINT m_ssfrWidth = 0;  // 半解像度幅
     UINT m_ssfrHeight = 0; // 半解像度高さ
 
-    D3D12_GPU_DESCRIPTOR_HANDLE m_ssfrSrvTableBase{}; // 合成パス用 SRV テーブル先頭
     UINT m_descriptorIncrement = 0; // CBV/SRV/UAV ヒープのインクリメント
 
     void RenderSSFR(ID3D12GraphicsCommandList* cmd, const Camera& camera); // SSFR 描画処理本体


### PR DESCRIPTION
## Summary
- adjust the SSFR render path to use half-resolution viewport/scissor and restore full-resolution settings afterward
- update the SSFR composite root signature and descriptor bindings to avoid misaligned SRV tables
- remove unused SRV table tracking now that resources are bound individually

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6078f51288332aaa40ad3cca6c47e