### PR TITLE
Fix SSFR constant buffer binding

### DIFF
--- a/DirectX12/SharedStruct.hlsli
+++ b/DirectX12/SharedStruct.hlsli
@@ -1,9 +1,7 @@
 #ifndef SHARED_STRUCT_HLSLI
 #define SHARED_STRUCT_HLSLI
 
-    float2 framebufferSize; // UVvZt𑜓x֍킹
-    float2 _pad;            // 萔obt@̃AC
-// カメラ系
+// ※PS 側で CBV b0 のみを参照できるよう、framebufferSize を CameraCB 内へ整理（RS 警告対策）
 cbuffer CameraCB : register(b0)
 {
     float4x4 proj;
@@ -11,8 +9,10 @@ cbuffer CameraCB : register(b0)
     float2 screenSize;
     float nearZ;
     float farZ;
-    float3 iorF0; // 例: (0.02,0.02,0.02)
-    float absorb; // 吸収係数
+    float3 iorF0;           // 例: (0.02,0.02,0.02)
+    float absorb;           // 吸収係数
+    float2 framebufferSize; // 合成用のフル解像度を保持（b2 参照エラー防止のため移動）
+    float2 _pad;            // 16byte 境界を維持
 }
 
 // 流体パラメータ


### PR DESCRIPTION
## Summary
- move framebufferSize and padding into CameraCB so the SSFR pixel shaders use only CBV b0
- document the reason for the constant buffer layout adjustment to avoid root signature warnings

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e613267d5883328e0fb7bc58bc2922